### PR TITLE
Add `UserStore` interface

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -410,10 +410,10 @@ func (server *ServerStruct) completeSignupAction(actionInvocationId string, sign
 	}
 
 	user, err := server.userStore.CreateUser(signup.emailAddress, signup.passwordHash, signup.passwordHashAlgorithmId, signup.passwordSalt)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return actionSessionStruct{}, "", newActionError(errorCodeInternalConflict)
 	}
-	if err != nil && errors.Is(err, ErrUserEmailAddressAlreadyUsed) {
+	if err != nil && errors.Is(err, ErrUserStoreUserEmailAddressAlreadyUsed) {
 		err = server.deleteSignup(signup.id)
 		if err != nil && !errors.Is(err, errSignupNotFound) {
 			errorMessage := fmt.Sprintf("failed to delete signup: %s", err.Error())
@@ -467,7 +467,7 @@ func (server *ServerStruct) createSigninAction(actionInvocationId string, userEm
 	}
 
 	user, err := server.userStore.GetUserByEmailAddress(userEmailAddress)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return actionSigninStruct{}, "", newActionError(errorCodeUserNotFound)
 	}
 	if err != nil {
@@ -1212,7 +1212,7 @@ func (server *ServerStruct) completeUserEmailAddressUpdateAction(actionInvocatio
 	}
 
 	err = server.userStore.UpdateUserEmailAddress(userEmailAddressUpdate.userId, userEmailAddressUpdate.newEmailAddress, user.EmailAddressCounter)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return newActionError(errorCodeInternalConflict)
 	}
 	if err != nil {
@@ -1555,7 +1555,7 @@ func (server *ServerStruct) completeUserPasswordUpdateAction(actionInvocationId 
 	}
 
 	err = server.userStore.UpdateUserPasswordHash(userPasswordUpdate.userId, userPasswordUpdate.newPasswordHash, userPasswordUpdate.newPasswordHashAlgorithmId, userPasswordUpdate.newPasswordSalt, user.PasswordHashCounter)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return newActionError(errorCodeInternalConflict)
 	}
 	if err != nil {
@@ -1814,7 +1814,7 @@ func (server *ServerStruct) completeUserDeletionAction(actionInvocationId string
 	}
 
 	err = server.userStore.DeleteUser(userDeletion.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return newActionError(errorCodeInternalConflict)
 	}
 	if err != nil {
@@ -1848,7 +1848,7 @@ func (server *ServerStruct) createUserPasswordResetAction(actionInvocationId str
 	}
 
 	user, err := server.userStore.GetUserByEmailAddress(userEmailAddress)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return actionUserPasswordResetStruct{}, "", newActionError(errorCodeUserNotFound)
 	}
 	if err != nil {
@@ -2139,7 +2139,7 @@ func (server *ServerStruct) completeUserPasswordResetAction(actionInvocationId s
 		userPasswordReset.newPasswordSalt,
 		userPasswordReset.userPasswordHashCounter,
 	)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return actionSessionStruct{}, "", newActionError(errorCodeInternalConflict)
 	}
 	if err != nil {

--- a/error.go
+++ b/error.go
@@ -25,7 +25,4 @@ var errInvalidUserDeletionToken = errors.New("invalid user deletion token")
 var errSigninNotFound = errors.New("signin not found")
 var errInvalidSigninToken = errors.New("invalid signin token")
 
-var errUserNotFound = errors.New("user not found")
-var errUserEmailAddressAlreadyUsed = errors.New("user email address already used")
-
 var errConflict = errors.New("conflict")

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,5 @@ module github.com/faroedev/faroe
 go 1.25.0
 
 require golang.org/x/sync v0.16.0 // direct
+
 require github.com/faroedev/go-json v0.1.1

--- a/server.go
+++ b/server.go
@@ -11,15 +11,16 @@ type ServerStruct struct {
 	mainStorage MainStorageInterface
 	cache       CacheInterface
 
-	errorLogger                        ActionErrorLoggerInterface
-	userPasswordHashAlgorithms         []PasswordHashAlgorithmInterface
-	temporaryPasswordHashAlgorithm     PasswordHashAlgorithmInterface
-	passwordHashingSemaphore           *semaphore.Weighted
-	clock                              ClockInterface
-	userServerInvocationEndpointClient ActionInvocationEndpointClientInterface
-	newEmailAddressChecker             EmailAddressCheckerInterface
-	emailSender                        EmailSenderInterface
-	sessionConfig                      SessionConfigStruct
+	userStore UserStoreInterface
+
+	errorLogger                    ActionErrorLoggerInterface
+	userPasswordHashAlgorithms     []PasswordHashAlgorithmInterface
+	temporaryPasswordHashAlgorithm PasswordHashAlgorithmInterface
+	passwordHashingSemaphore       *semaphore.Weighted
+	clock                          ClockInterface
+	newEmailAddressChecker         EmailAddressCheckerInterface
+	emailSender                    EmailSenderInterface
+	sessionConfig                  SessionConfigStruct
 
 	verifyUserPasswordRateLimit                             *tokenBucketRateLimit
 	sendEmailRateLimit                                      *tokenBucketRateLimit
@@ -41,6 +42,7 @@ func NewServer(
 	mainStorage MainStorageInterface,
 	cache CacheInterface,
 	rateLimitStorage RateLimitStorageInterface,
+	userStore UserStoreInterface,
 	errorLogger ActionErrorLoggerInterface,
 	userPasswordHashAlgorithms []PasswordHashAlgorithmInterface,
 	temporaryPasswordHashAlgorithm PasswordHashAlgorithmInterface,
@@ -48,7 +50,6 @@ func NewServer(
 	clock ClockInterface,
 	newEmailAddressChecker EmailAddressCheckerInterface,
 	emailSender EmailSenderInterface,
-	userServerActionInvocationEndpointClient ActionInvocationEndpointClientInterface,
 	sessionConfig SessionConfigStruct,
 ) *ServerStruct {
 	verifyUserPasswordRateLimit := newTokenBucketRateLimit(rateLimitStorage, rateLimitStorageKeyPrefixVerifyUserPasswordRateLimit, clock, 5, time.Minute)
@@ -57,17 +58,17 @@ func NewServer(
 	verifyUserPasswordResetTemporaryPasswordUserRateLimit := newTokenBucketRateLimit(rateLimitStorage, rateLimitStorageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit, clock, 5, time.Minute)
 
 	action := &ServerStruct{
-		mainStorage:                        mainStorage,
-		cache:                              cache,
-		errorLogger:                        errorLogger,
-		userPasswordHashAlgorithms:         userPasswordHashAlgorithms,
-		temporaryPasswordHashAlgorithm:     temporaryPasswordHashAlgorithm,
-		passwordHashingSemaphore:           semaphore.NewWeighted(int64(maxConcurrentPasswordHashingProcesses)),
-		clock:                              clock,
-		userServerInvocationEndpointClient: userServerActionInvocationEndpointClient,
-		newEmailAddressChecker:             newEmailAddressChecker,
-		emailSender:                        emailSender,
-		sessionConfig:                      sessionConfig,
+		mainStorage:                    mainStorage,
+		cache:                          cache,
+		userStore:                      userStore,
+		errorLogger:                    errorLogger,
+		userPasswordHashAlgorithms:     userPasswordHashAlgorithms,
+		temporaryPasswordHashAlgorithm: temporaryPasswordHashAlgorithm,
+		passwordHashingSemaphore:       semaphore.NewWeighted(int64(maxConcurrentPasswordHashingProcesses)),
+		clock:                          clock,
+		newEmailAddressChecker:         newEmailAddressChecker,
+		emailSender:                    emailSender,
+		sessionConfig:                  sessionConfig,
 
 		verifyUserPasswordRateLimit:                             verifyUserPasswordRateLimit,
 		sendEmailRateLimit:                                      sendEmailRateLimit,

--- a/session.go
+++ b/session.go
@@ -160,7 +160,7 @@ func (server *ServerStruct) getValidSessionAndUser(sessionId string) (cachedSess
 		expirationValid := server.verifyCachedSessionExpiration(cachedSession)
 		if expirationValid {
 			user, err := server.userStore.GetUser(cachedSession.userId)
-			if err != nil && errors.Is(err, ErrUserNotFound) {
+			if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 				err = server.deleteSessionFromCache(cachedSession.id)
 				if err != nil {
 					return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
@@ -208,7 +208,7 @@ func (server *ServerStruct) getValidSessionAndUser(sessionId string) (cachedSess
 	}
 
 	user, err := server.userStore.GetUser(session.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
 			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
@@ -291,7 +291,7 @@ func (server *ServerStruct) getValidSession(sessionId string) (cachedSessionStru
 	}
 
 	user, err := server.userStore.GetUser(session.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
 			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())

--- a/signin.go
+++ b/signin.go
@@ -87,7 +87,7 @@ func (server *ServerStruct) getValidSigninAndUser(signinId string) (signinStruct
 	}
 
 	user, err := server.userStore.GetUser(signin.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSigninFromMainStorage(signin.id)
 		if err != nil && !errors.Is(err, errSigninNotFound) {
 			return signinStruct{}, UserStruct{}, fmt.Errorf("failed to delete signin from main storage: %s", err.Error())

--- a/user-deletion.go
+++ b/user-deletion.go
@@ -90,7 +90,7 @@ func (server *ServerStruct) getValidUserDeletionAndUser(userDeletionId string) (
 	}
 
 	user, err := server.userStore.GetUser(userDeletion.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteUserDeletionFromMainStorage(userDeletion.id)
 		if err != nil && errors.Is(err, errUserDeletionNotFound) {
 			return userDeletionStruct{}, UserStruct{}, fmt.Errorf("failed to delete user deletion from main storage: %s", err.Error())

--- a/user-email-address-update.go
+++ b/user-email-address-update.go
@@ -98,7 +98,7 @@ func (server *ServerStruct) getValidUserEmailAddressUpdateAndUser(userEmailAddre
 	}
 
 	user, err := server.userStore.GetUser(userEmailAddressUpdate.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteUserEmailAddressUpdateFromMainStorage(userEmailAddressUpdate.id)
 		if err != nil && !errors.Is(err, errUserEmailAddressUpdateNotFound) {
 			return userEmailAddressUpdateStruct{}, UserStruct{}, fmt.Errorf("failed to delete email address update from main storage: %s", err.Error())

--- a/user-password-reset.go
+++ b/user-password-reset.go
@@ -109,7 +109,7 @@ func (server *ServerStruct) getValidUserPasswordResetAndUser(userPasswordResetId
 	}
 
 	user, err := server.userStore.GetUser(userPasswordReset.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteUserPasswordResetFromMainStorage(userPasswordReset.id)
 		if err != nil && !errors.Is(err, errUserPasswordResetNotFound) {
 			return userPasswordResetStruct{}, UserStruct{}, fmt.Errorf("failed to delete user password reset from main storage: %s", err.Error())

--- a/user-password-update.go
+++ b/user-password-update.go
@@ -98,7 +98,7 @@ func (server *ServerStruct) getValidUserPasswordUpdateAndUser(userPasswordUpdate
 	}
 
 	user, err := server.userStore.GetUser(userPasswordUpdate.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteUserPasswordUpdateFromMainStorage(userPasswordUpdate.id)
 		if err != nil && !errors.Is(err, errUserPasswordUpdateNotFound) {
 			return userPasswordUpdateStruct{}, UserStruct{}, fmt.Errorf("failed to delete user password update from main storage: %s", err.Error())

--- a/user-server.go
+++ b/user-server.go
@@ -50,7 +50,7 @@ func (userServerClient *UserServerClientStruct) CreateUser(emailAddress string, 
 				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return UserStruct{}, ErrUserEmailAddressAlreadyUsed
+				return UserStruct{}, ErrUserStoreUserEmailAddressAlreadyUsed
 			}
 			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -85,7 +85,7 @@ func (userServerClient *UserServerClientStruct) GetUser(userId string) (UserStru
 				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return UserStruct{}, ErrUserNotFound
+				return UserStruct{}, ErrUserStoreUserNotFound
 			}
 			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -120,7 +120,7 @@ func (userServerClient *UserServerClientStruct) GetUserByEmailAddress(emailAddre
 				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return UserStruct{}, ErrUserNotFound
+				return UserStruct{}, ErrUserStoreUserNotFound
 			}
 			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -157,10 +157,10 @@ func (userServerClient *UserServerClientStruct) UpdateUserEmailAddress(userId st
 				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return ErrUserNotFound
+				return ErrUserStoreUserNotFound
 			}
 			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return ErrUserEmailAddressAlreadyUsed
+				return ErrUserStoreUserEmailAddressAlreadyUsed
 			}
 			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -192,10 +192,10 @@ func (userServerClient *UserServerClientStruct) UpdateUserPasswordHash(userId st
 				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return ErrUserNotFound
+				return ErrUserStoreUserNotFound
 			}
 			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return ErrUserEmailAddressAlreadyUsed
+				return ErrUserStoreUserEmailAddressAlreadyUsed
 			}
 			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -221,10 +221,10 @@ func (userServerClient *UserServerClientStruct) IncrementUserSessionsCounter(use
 				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return ErrUserNotFound
+				return ErrUserStoreUserNotFound
 			}
 			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return ErrUserEmailAddressAlreadyUsed
+				return ErrUserStoreUserEmailAddressAlreadyUsed
 			}
 			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -249,7 +249,7 @@ func (userServerClient *UserServerClientStruct) DeleteUser(userId string) error 
 				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return ErrUserNotFound
+				return ErrUserStoreUserNotFound
 			}
 			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -261,7 +261,7 @@ func (userServerClient *UserServerClientStruct) DeleteUser(userId string) error 
 
 func (server *ServerStruct) checkEmailAddressAvailability(emailAddress string) (bool, error) {
 	_, err := server.userStore.GetUserByEmailAddress(emailAddress)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return true, nil
 	}
 	if err != nil {

--- a/user-server.go
+++ b/user-server.go
@@ -8,6 +8,16 @@ import (
 	"github.com/faroedev/go-json"
 )
 
+const (
+	userServerActionCreateUser                   = "create_user"
+	userServerActionGetUser                      = "get_user"
+	userServerActionGetUserByEmailAddress        = "get_user_by_email_address"
+	userServerActionUpdateUserEmailAddress       = "update_user_email_address"
+	userServerActionUpdateUserPasswordHash       = "update_user_password_hash"
+	userServerActionIncrementUserSessionsCounter = "increment_user_sessions_counter"
+	userServerActionDeleteUser                   = "delete_user"
+)
+
 // Use [NewUserServerClient].
 // Implements [UserStoreInterface].
 type UserServerClientStruct struct {

--- a/user-server.go
+++ b/user-server.go
@@ -1,0 +1,333 @@
+package faroe
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/faroedev/go-json"
+)
+
+// Use [NewUserServerClient].
+// Implements [UserStoreInterface].
+type UserServerClientStruct struct {
+	actionInvocationEndpointClient ActionInvocationEndpointClientInterface
+}
+
+func NewUserServerClient(actionInvocationEndpointClient ActionInvocationEndpointClientInterface) *UserServerClientStruct {
+	client := &UserServerClientStruct{actionInvocationEndpointClient: actionInvocationEndpointClient}
+	return client
+}
+
+func (userServerClient *UserServerClientStruct) CreateUser(emailAddress string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte) (UserStruct, error) {
+	encodedPasswordHash := base64.StdEncoding.EncodeToString(passwordHash)
+	encodedPasswordSalt := base64.StdEncoding.EncodeToString(passwordSalt)
+
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("email_address", emailAddress)
+	argumentsJSONBuilder.AddString("password_hash", encodedPasswordHash)
+	argumentsJSONBuilder.AddString("password_hash_algorithm_id", passwordHashAlgorithmId)
+	argumentsJSONBuilder.AddString("password_salt", encodedPasswordSalt)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, valuesJSONObject, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionCreateUser, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "email_address_already_used" {
+				return UserStruct{}, ErrUserEmailAddressAlreadyUsed
+			}
+			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return UserStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
+	}
+
+	user, err := mapJSONObjectToUser(userJSONObject)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
+	}
+
+	return user, nil
+}
+
+func (userServerClient *UserServerClientStruct) GetUser(userId string) (UserStruct, error) {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, valuesJSONObject, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionGetUser, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return UserStruct{}, ErrUserNotFound
+			}
+			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return UserStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
+	}
+
+	user, err := mapJSONObjectToUser(userJSONObject)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
+	}
+
+	return user, nil
+}
+
+func (userServerClient *UserServerClientStruct) GetUserByEmailAddress(emailAddress string) (UserStruct, error) {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("email_address", emailAddress)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, valuesJSONObject, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionGetUserByEmailAddress, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return UserStruct{}, ErrUserNotFound
+			}
+			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return UserStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
+	}
+
+	user, err := mapJSONObjectToUser(userJSONObject)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
+	}
+
+	return user, nil
+}
+
+func (userServerClient *UserServerClientStruct) UpdateUserEmailAddress(userId string, emailAddress string, userEmailAddressCounter int32) error {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSONBuilder.AddString("email_address", emailAddress)
+	argumentsJSONBuilder.AddInt32("user_email_address_counter", userEmailAddressCounter)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, _, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionUpdateUserEmailAddress, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return ErrUserNotFound
+			}
+			if actionInvocationActionErr.errorCode == "email_address_already_used" {
+				return ErrUserEmailAddressAlreadyUsed
+			}
+			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (userServerClient *UserServerClientStruct) UpdateUserPasswordHash(userId string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte, userPasswordHashCounter int32) error {
+	encodedPasswordHash := base64.StdEncoding.EncodeToString(passwordHash)
+	encodedPasswordSalt := base64.StdEncoding.EncodeToString(passwordSalt)
+
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSONBuilder.AddString("password_hash", encodedPasswordHash)
+	argumentsJSONBuilder.AddString("password_hash_algorithm_id", passwordHashAlgorithmId)
+	argumentsJSONBuilder.AddString("password_salt", encodedPasswordSalt)
+	argumentsJSONBuilder.AddInt32("user_password_hash_counter", userPasswordHashCounter)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, _, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionUpdateUserPasswordHash, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return ErrUserNotFound
+			}
+			if actionInvocationActionErr.errorCode == "email_address_already_used" {
+				return ErrUserEmailAddressAlreadyUsed
+			}
+			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (userServerClient *UserServerClientStruct) IncrementUserSessionsCounter(userId string, userSessionsCounter int32) error {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSONBuilder.AddInt32("user_sessions_counter", userSessionsCounter)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, _, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionIncrementUserSessionsCounter, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return ErrUserNotFound
+			}
+			if actionInvocationActionErr.errorCode == "email_address_already_used" {
+				return ErrUserEmailAddressAlreadyUsed
+			}
+			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (userServerClient *UserServerClientStruct) DeleteUser(userId string) error {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, _, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionDeleteUser, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return ErrUserNotFound
+			}
+			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (server *ServerStruct) checkEmailAddressAvailability(emailAddress string) (bool, error) {
+	_, err := server.userStore.GetUserByEmailAddress(emailAddress)
+	if err != nil && errors.Is(err, ErrUserNotFound) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to get user from user api: %s", err.Error())
+	}
+	return false, nil
+}
+
+func mapJSONObjectToUser(userJSON json.ObjectStruct) (UserStruct, error) {
+	userId, err := userJSON.GetString("id")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'id' field: %s", err.Error())
+	}
+	emailAddress, err := userJSON.GetString("email_address")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'email_address' field: %s", err.Error())
+	}
+	encodedPasswordHash, err := userJSON.GetString("password_hash")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'password_hash' field: %s", err.Error())
+	}
+	passwordHashAlgorithmId, err := userJSON.GetString("password_hash_algorithm_id")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'password_hash_algorithm_id' field: %s", err.Error())
+	}
+	encodedPasswordSalt, err := userJSON.GetString("password_salt")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'password_salt' field: %s", err.Error())
+	}
+	displayName, err := userJSON.GetString("display_name")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'display_name' field: %s", err.Error())
+	}
+	disabled, err := userJSON.GetBool("disabled")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'disabled' field: %s", err.Error())
+	}
+	emailAddressCounter, err := userJSON.GetInt32("email_address_counter")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'email_address_counter' field: %s", err.Error())
+	}
+	passwordHashCounter, err := userJSON.GetInt32("password_hash_counter")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'password_hash_counter' field: %s", err.Error())
+	}
+	disabledCounter, err := userJSON.GetInt32("disabled_counter")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'disabled_counter' field: %s", err.Error())
+	}
+	sessionsCounter, err := userJSON.GetInt32("sessions_counter")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'sessions_counter' field: %s", err.Error())
+	}
+
+	passwordHash, err := base64.StdEncoding.DecodeString(encodedPasswordHash)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to decode password hash: %s", err.Error())
+	}
+	passwordSalt, err := base64.StdEncoding.DecodeString(encodedPasswordSalt)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to decode password salt: %s", err.Error())
+	}
+
+	user := UserStruct{
+		Id:                      userId,
+		EmailAddress:            emailAddress,
+		PasswordHash:            passwordHash,
+		PasswordSalt:            passwordSalt,
+		PasswordHashAlgorithmId: passwordHashAlgorithmId,
+		DisplayName:             displayName,
+		Disabled:                disabled,
+		EmailAddressCounter:     emailAddressCounter,
+		PasswordHashCounter:     passwordHashCounter,
+		DisabledCounter:         disabledCounter,
+		SessionsCounter:         sessionsCounter,
+	}
+
+	return user, nil
+}

--- a/user.go
+++ b/user.go
@@ -33,44 +33,44 @@ type UserStoreInterface interface {
 	// Creates a new user. The email address should be stored as-is, with the casing preserved.
 	// The email address counter, password hash counter, disabled counter, and sessions counter should be set to 0.
 	// Returns the created user if successful.
-	// Returns [ErrUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
+	// Returns [ErrUserStoreUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
 	// An error is returned for any other failure.
 	CreateUser(emailAddress string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte) (UserStruct, error)
 
 	// Gets a user.
-	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist.
 	// An error is returned for any other failure.
 	GetUser(userId string) (UserStruct, error)
 
 	// Gets a user by email address.
 	// The email address must match exactly, including letter casing.
-	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist.
 	// An error is returned for any other failure.
 	GetUserByEmailAddress(emailAddress string) (UserStruct, error)
 
 	// Updates a user's email address and increment a user's email address counter if the email address counter matches.
 	// The new email address should be stored as-is, with the casing preserved.
-	// Returns [ErrUserNotFound] if a user doesn't exist or the user's email address counter doesn't match.
-	// Returns [ErrUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist or the user's email address counter doesn't match.
+	// Returns [ErrUserStoreUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
 	// An error is returned for any other failure.
 	UpdateUserEmailAddress(userId string, emailAddress string, userEmailAddressCounter int32) error
 
 	// Updates a user's password hash, password hash algorithm ID, and password salt,
 	// as well as increment a user's email address counter, if the user password hash counter matches.
-	// Returns [ErrUserNotFound] if a user doesn't exist or the user's password hash counter doesn't match.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist or the user's password hash counter doesn't match.
 	// An error is returned for any other failure.
 	UpdateUserPasswordHash(userId string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte, userPasswordHashCounter int32) error
 
 	// Increments a user's sessions counter if the user's sessions counter matches.
-	// Returns [ErrUserNotFound] if a user doesn't exist or the user's sessions counter doesn't match.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist or the user's sessions counter doesn't match.
 	// An error is returned for any other failure.
 	IncrementUserSessionsCounter(userId string, userSessionsCounter int32) error
 
 	// Deletes a user.
-	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist.
 	// An error is returned for any other failure.
 	DeleteUser(userId string) error
 }
 
-var ErrUserNotFound = errors.New("user not found")
-var ErrUserEmailAddressAlreadyUsed = errors.New("user email address already used")
+var ErrUserStoreUserNotFound = errors.New("user not found")
+var ErrUserStoreUserEmailAddressAlreadyUsed = errors.New("user email address already used")

--- a/user.go
+++ b/user.go
@@ -1,12 +1,6 @@
 package faroe
 
-import (
-	"encoding/base64"
-	"errors"
-	"fmt"
-
-	"github.com/faroedev/go-json"
-)
+import "errors"
 
 const (
 	userServerActionCreateUser                   = "create_user"
@@ -18,329 +12,75 @@ const (
 	userServerActionDeleteUser                   = "delete_user"
 )
 
-type userStruct struct {
-	id                      string
-	emailAddress            string
-	passwordHash            []byte
-	passwordSalt            []byte
-	passwordHashAlgorithmId string
-	disabled                bool
-	displayName             string
-	emailAddressCounter     int32
-	passwordHashCounter     int32
-	disabledCounter         int32
-	sessionsCounter         int32
+type UserStruct struct {
+	// A unique ID.
+	Id string
+
+	// A unique email address.
+	EmailAddress string
+
+	PasswordHash []byte
+
+	PasswordSalt []byte
+
+	PasswordHashAlgorithmId string
+
+	Disabled bool
+
+	// An empty string if not defined.
+	DisplayName string
+
+	EmailAddressCounter int32
+
+	PasswordHashCounter int32
+
+	DisabledCounter int32
+
+	SessionsCounter int32
 }
 
-func (server *ServerStruct) createUser(emailAddress string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte) (userStruct, error) {
-	encodedPasswordHash := base64.StdEncoding.EncodeToString(passwordHash)
-	encodedPasswordSalt := base64.StdEncoding.EncodeToString(passwordSalt)
+type UserStoreInterface interface {
+	// Creates a new user. The email address should be stored as-is, with the casing preserved.
+	// The email address counter, password hash counter, disabled counter, and sessions counter should be set to 0.
+	// Returns the created user if successful.
+	// Returns [ErrUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
+	// An error is returned for any other failure.
+	CreateUser(emailAddress string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte) (UserStruct, error)
 
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("email_address", emailAddress)
-	argumentsJSONBuilder.AddString("password_hash", encodedPasswordHash)
-	argumentsJSONBuilder.AddString("password_hash_algorithm_id", passwordHashAlgorithmId)
-	argumentsJSONBuilder.AddString("password_salt", encodedPasswordSalt)
-	argumentsJSON := argumentsJSONBuilder.Done()
+	// Gets a user.
+	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// An error is returned for any other failure.
+	GetUser(userId string) (UserStruct, error)
 
-	_, valuesJSONObject, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionCreateUser, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return userStruct{}, errUserEmailAddressAlreadyUsed
-			}
-			return userStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return userStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
+	// Gets a user by email address.
+	// The email address must match exactly, including letter casing.
+	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// An error is returned for any other failure.
+	GetUserByEmailAddress(emailAddress string) (UserStruct, error)
 
-	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
-	}
+	// Updates a user's email address and increment a user's email address counter if the email address counter matches.
+	// The new email address should be stored as-is, with the casing preserved.
+	// Returns [ErrUserNotFound] if a user doesn't exist or the user's email address counter doesn't match.
+	// Returns [ErrUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
+	// An error is returned for any other failure.
+	UpdateUserEmailAddress(userId string, emailAddress string, userEmailAddressCounter int32) error
 
-	user, err := mapJSONObjectToUser(userJSONObject)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
-	}
+	// Updates a user's password hash, password hash algorithm ID, and password salt,
+	// as well as increment a user's email address counter, if the user password hash counter matches.
+	// Returns [ErrUserNotFound] if a user doesn't exist or the user's password hash counter doesn't match.
+	// An error is returned for any other failure.
+	UpdateUserPasswordHash(userId string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte, userPasswordHashCounter int32) error
 
-	return user, nil
+	// Increments a user's sessions counter if the user's sessions counter matches.
+	// Returns [ErrUserNotFound] if a user doesn't exist or the user's sessions counter doesn't match.
+	// An error is returned for any other failure.
+	IncrementUserSessionsCounter(userId string, userSessionsCounter int32) error
+
+	// Deletes a user.
+	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// An error is returned for any other failure.
+	DeleteUser(userId string) error
 }
 
-func (server *ServerStruct) getUser(userId string) (userStruct, error) {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, valuesJSONObject, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionGetUser, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return userStruct{}, errUserNotFound
-			}
-			return userStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return userStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
-	}
-
-	user, err := mapJSONObjectToUser(userJSONObject)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
-	}
-
-	return user, nil
-}
-
-func (server *ServerStruct) getUserByEmailAddress(emailAddress string) (userStruct, error) {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("email_address", emailAddress)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, valuesJSONObject, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionGetUserByEmailAddress, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return userStruct{}, errUserNotFound
-			}
-			return userStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return userStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
-	}
-
-	user, err := mapJSONObjectToUser(userJSONObject)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
-	}
-
-	return user, nil
-}
-
-func (server *ServerStruct) updateUserEmailAddress(userId string, emailAddress string, userEmailAddressCounter int32) error {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSONBuilder.AddString("email_address", emailAddress)
-	argumentsJSONBuilder.AddInt32("user_email_address_counter", userEmailAddressCounter)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, _, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionUpdateUserEmailAddress, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return errUserNotFound
-			}
-			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return errUserEmailAddressAlreadyUsed
-			}
-			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) updateUserPasswordHash(userId string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte, userPasswordHashCounter int32) error {
-	encodedPasswordHash := base64.StdEncoding.EncodeToString(passwordHash)
-	encodedPasswordSalt := base64.StdEncoding.EncodeToString(passwordSalt)
-
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSONBuilder.AddString("password_hash", encodedPasswordHash)
-	argumentsJSONBuilder.AddString("password_hash_algorithm_id", passwordHashAlgorithmId)
-	argumentsJSONBuilder.AddString("password_salt", encodedPasswordSalt)
-	argumentsJSONBuilder.AddInt32("user_password_hash_counter", userPasswordHashCounter)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, _, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionUpdateUserPasswordHash, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return errUserNotFound
-			}
-			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return errUserEmailAddressAlreadyUsed
-			}
-			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) incrementUserSessionsCounter(userId string, userSessionsCounter int32) error {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSONBuilder.AddInt32("user_sessions_counter", userSessionsCounter)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, _, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionIncrementUserSessionsCounter, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return errUserNotFound
-			}
-			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return errUserEmailAddressAlreadyUsed
-			}
-			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) deleteUser(userId string) error {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, _, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionDeleteUser, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return errUserNotFound
-			}
-			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) checkEmailAddressAvailability(emailAddress string) (bool, error) {
-	_, err := server.getUserByEmailAddress(emailAddress)
-	if err != nil && errors.Is(err, errUserNotFound) {
-		return true, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("failed to get user from user api: %s", err.Error())
-	}
-	return false, nil
-}
-
-func mapJSONObjectToUser(userJSON json.ObjectStruct) (userStruct, error) {
-	userId, err := userJSON.GetString("id")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'id' field: %s", err.Error())
-	}
-	emailAddress, err := userJSON.GetString("email_address")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'email_address' field: %s", err.Error())
-	}
-	encodedPasswordHash, err := userJSON.GetString("password_hash")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'password_hash' field: %s", err.Error())
-	}
-	passwordHashAlgorithmId, err := userJSON.GetString("password_hash_algorithm_id")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'password_hash_algorithm_id' field: %s", err.Error())
-	}
-	encodedPasswordSalt, err := userJSON.GetString("password_salt")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'password_salt' field: %s", err.Error())
-	}
-	displayName, err := userJSON.GetString("display_name")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'display_name' field: %s", err.Error())
-	}
-	disabled, err := userJSON.GetBool("disabled")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'disabled' field: %s", err.Error())
-	}
-	emailAddressCounter, err := userJSON.GetInt32("email_address_counter")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'email_address_counter' field: %s", err.Error())
-	}
-	passwordHashCounter, err := userJSON.GetInt32("password_hash_counter")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'password_hash_counter' field: %s", err.Error())
-	}
-	disabledCounter, err := userJSON.GetInt32("disabled_counter")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'disabled_counter' field: %s", err.Error())
-	}
-	sessionsCounter, err := userJSON.GetInt32("sessions_counter")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'sessions_counter' field: %s", err.Error())
-	}
-
-	passwordHash, err := base64.StdEncoding.DecodeString(encodedPasswordHash)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to decode password hash: %s", err.Error())
-	}
-	passwordSalt, err := base64.StdEncoding.DecodeString(encodedPasswordSalt)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to decode password salt: %s", err.Error())
-	}
-
-	user := userStruct{
-		id:                      userId,
-		emailAddress:            emailAddress,
-		passwordHash:            passwordHash,
-		passwordSalt:            passwordSalt,
-		passwordHashAlgorithmId: passwordHashAlgorithmId,
-		displayName:             displayName,
-		disabled:                disabled,
-		emailAddressCounter:     emailAddressCounter,
-		passwordHashCounter:     passwordHashCounter,
-		disabledCounter:         disabledCounter,
-		sessionsCounter:         sessionsCounter,
-	}
-
-	return user, nil
-}
+var ErrUserNotFound = errors.New("user not found")
+var ErrUserEmailAddressAlreadyUsed = errors.New("user email address already used")

--- a/user.go
+++ b/user.go
@@ -2,16 +2,6 @@ package faroe
 
 import "errors"
 
-const (
-	userServerActionCreateUser                   = "create_user"
-	userServerActionGetUser                      = "get_user"
-	userServerActionGetUserByEmailAddress        = "get_user_by_email_address"
-	userServerActionUpdateUserEmailAddress       = "update_user_email_address"
-	userServerActionUpdateUserPasswordHash       = "update_user_password_hash"
-	userServerActionIncrementUserSessionsCounter = "increment_user_sessions_counter"
-	userServerActionDeleteUser                   = "delete_user"
-)
-
 type UserStruct struct {
 	// A unique ID.
 	Id string


### PR DESCRIPTION
Resolves #2 

Adds a `UserStoreInterface` interface. `NewServer()` now takes a `UserStoreInterface` instead of a `ActionInvocationEndpointClientInterface` for the user server. `userStruct`, `errUserNotFound`, and `errUserEmailAddressAlreadyUsed` are now `UserStruct`, `ErrUserStoreUserNotFound`, and `ErrUserStoreUserEmailAddressAlreadyUsed `.

Also adds a `UserServerClientStruct` and `NewUserServerClient()` to provide a similar API.