### PR TITLE
Simplify storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ import "github.com/faroedev/faroe"
 
 func main() {
 	server := faroe.NewServer(
-		mainStorage,
-		cache,
-		rateLimitStorage,
+		storage,
 		userStore,
 		logger,
 		userPasswordHashAlgorithms,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Some key features of the server:
 
 1. Takes care of all the hard parts. Passwords, email address verification, sessions, rate limiting, password resets, and more.
 2. Extends your existing user database instead of replacing it. Own and customize your user data. No more data synchronization between servers.
-3. No direct connections to your database. Just basic HTTP requests.
+3. No direct connections to your database.
 4. Only ephemeral data is stored. Less things to manage and worry about.
 
 ```ts
@@ -39,6 +39,7 @@ func main() {
 		mainStorage,
 		cache,
 		rateLimitStorage,
+		userStore,
 		logger,
 		userPasswordHashAlgorithms,
 		temporaryPasswordHashAlgorithm,
@@ -46,7 +47,6 @@ func main() {
 		faroe.RealClock,
 		faroe.AllowAllEmailAddresses,
 		emailSender,
-		userActionInvocationEndpointClient,
 		sessionConfig,
 	)
 }

--- a/actions.go
+++ b/actions.go
@@ -410,10 +410,10 @@ func (server *ServerStruct) completeSignupAction(actionInvocationId string, sign
 	}
 
 	user, err := server.userStore.CreateUser(signup.emailAddress, signup.passwordHash, signup.passwordHashAlgorithmId, signup.passwordSalt)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return actionSessionStruct{}, "", newActionError(errorCodeInternalConflict)
 	}
-	if err != nil && errors.Is(err, ErrUserEmailAddressAlreadyUsed) {
+	if err != nil && errors.Is(err, ErrUserStoreUserEmailAddressAlreadyUsed) {
 		err = server.deleteSignup(signup.id)
 		if err != nil && !errors.Is(err, errSignupNotFound) {
 			errorMessage := fmt.Sprintf("failed to delete signup: %s", err.Error())
@@ -467,7 +467,7 @@ func (server *ServerStruct) createSigninAction(actionInvocationId string, userEm
 	}
 
 	user, err := server.userStore.GetUserByEmailAddress(userEmailAddress)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return actionSigninStruct{}, "", newActionError(errorCodeUserNotFound)
 	}
 	if err != nil {
@@ -1212,7 +1212,7 @@ func (server *ServerStruct) completeUserEmailAddressUpdateAction(actionInvocatio
 	}
 
 	err = server.userStore.UpdateUserEmailAddress(userEmailAddressUpdate.userId, userEmailAddressUpdate.newEmailAddress, user.EmailAddressCounter)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return newActionError(errorCodeInternalConflict)
 	}
 	if err != nil {
@@ -1555,7 +1555,7 @@ func (server *ServerStruct) completeUserPasswordUpdateAction(actionInvocationId 
 	}
 
 	err = server.userStore.UpdateUserPasswordHash(userPasswordUpdate.userId, userPasswordUpdate.newPasswordHash, userPasswordUpdate.newPasswordHashAlgorithmId, userPasswordUpdate.newPasswordSalt, user.PasswordHashCounter)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return newActionError(errorCodeInternalConflict)
 	}
 	if err != nil {
@@ -1814,7 +1814,7 @@ func (server *ServerStruct) completeUserDeletionAction(actionInvocationId string
 	}
 
 	err = server.userStore.DeleteUser(userDeletion.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return newActionError(errorCodeInternalConflict)
 	}
 	if err != nil {
@@ -1848,7 +1848,7 @@ func (server *ServerStruct) createUserPasswordResetAction(actionInvocationId str
 	}
 
 	user, err := server.userStore.GetUserByEmailAddress(userEmailAddress)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return actionUserPasswordResetStruct{}, "", newActionError(errorCodeUserNotFound)
 	}
 	if err != nil {
@@ -2139,7 +2139,7 @@ func (server *ServerStruct) completeUserPasswordResetAction(actionInvocationId s
 		userPasswordReset.newPasswordSalt,
 		userPasswordReset.userPasswordHashCounter,
 	)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return actionSessionStruct{}, "", newActionError(errorCodeInternalConflict)
 	}
 	if err != nil {

--- a/actions.go
+++ b/actions.go
@@ -2239,7 +2239,7 @@ type actionSessionStruct struct {
 	expiresAtDefined bool
 }
 
-func (server *ServerStruct) createActionSession(session cachedSessionStruct) actionSessionStruct {
+func (server *ServerStruct) createActionSession(session sessionStruct) actionSessionStruct {
 	actionSession := actionSessionStruct{
 		id:               session.id,
 		userId:           session.userId,

--- a/actions.go
+++ b/actions.go
@@ -1203,8 +1203,8 @@ func (server *ServerStruct) completeUserEmailAddressUpdateAction(actionInvocatio
 	}
 	if !emailAddressAllowed {
 		err = server.deleteUserEmailAddressUpdate(userEmailAddressUpdate.id)
-		if err != nil && !errors.Is(err, errSignupNotFound) {
-			errorMessage := fmt.Sprintf("failed to delete signup: %s", err.Error())
+		if err != nil && !errors.Is(err, errUserEmailAddressUpdateNotFound) {
+			errorMessage := fmt.Sprintf("failed to delete user email address update: %s", err.Error())
 			server.errorLogger.LogActionError(server.clock.Now(), errorMessage, actionInvocationId, ActionCompleteUserEmailAddressUpdate)
 		}
 

--- a/actions.go
+++ b/actions.go
@@ -1577,7 +1577,7 @@ func (server *ServerStruct) completeUserPasswordUpdateAction(actionInvocationId 
 
 	err = server.deleteUserPasswordUpdate(userPasswordUpdate.id)
 	if err != nil && !errors.Is(err, errUserPasswordUpdateNotFound) {
-		errorMessage := fmt.Sprintf("failed to delete yser password update: %s", err.Error())
+		errorMessage := fmt.Sprintf("failed to delete user password update: %s", err.Error())
 		server.errorLogger.LogActionError(server.clock.Now(), errorMessage, actionInvocationId, ActionCompleteUserPasswordUpdate)
 	}
 

--- a/error.go
+++ b/error.go
@@ -25,7 +25,4 @@ var errInvalidUserDeletionToken = errors.New("invalid user deletion token")
 var errSigninNotFound = errors.New("signin not found")
 var errInvalidSigninToken = errors.New("invalid signin token")
 
-var errUserNotFound = errors.New("user not found")
-var errUserEmailAddressAlreadyUsed = errors.New("user email address already used")
-
 var errConflict = errors.New("conflict")

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,5 @@ module github.com/faroedev/faroe
 go 1.25.0
 
 require golang.org/x/sync v0.16.0 // direct
+
 require github.com/faroedev/go-json v0.1.1

--- a/server.go
+++ b/server.go
@@ -8,8 +8,7 @@ import (
 
 // Use [NewServer].
 type ServerStruct struct {
-	mainStorage MainStorageInterface
-	cache       CacheInterface
+	storage StorageInterface
 
 	userStore UserStoreInterface
 
@@ -30,8 +29,6 @@ type ServerStruct struct {
 
 // All interfaces must be defined and cannot be nil.
 //
-// Storage entry keys are not globally-scoped. Different entries in mainStorage, cache, and rateLimitStorage may share the same key.
-//
 // maxConcurrentPasswordHashingProcesses defines the maximum number of concurrent processes for user password and temporary password hashing.
 //
 // emailAddressChecker is used for checking email addresses for signup and new email addresses of user email address updates.
@@ -39,9 +36,7 @@ type ServerStruct struct {
 //
 // InactivityTimeout and ActivityCheckInterval should be a non-zero value in sessionConfig.
 func NewServer(
-	mainStorage MainStorageInterface,
-	cache CacheInterface,
-	rateLimitStorage RateLimitStorageInterface,
+	storage StorageInterface,
 	userStore UserStoreInterface,
 	errorLogger ActionErrorLoggerInterface,
 	userPasswordHashAlgorithms []PasswordHashAlgorithmInterface,
@@ -52,14 +47,13 @@ func NewServer(
 	emailSender EmailSenderInterface,
 	sessionConfig SessionConfigStruct,
 ) *ServerStruct {
-	verifyUserPasswordRateLimit := newTokenBucketRateLimit(rateLimitStorage, rateLimitStorageKeyPrefixVerifyUserPasswordRateLimit, clock, 5, time.Minute)
-	sendEmailRateLimit := newTokenBucketRateLimit(rateLimitStorage, rateLimitStorageKeyPrefixSendEmailRateLimit, clock, 5, 30*time.Minute)
-	verifyEmailAddressVerificationCodeEmailAddressRateLimit := newTokenBucketRateLimit(rateLimitStorage, rateLimitStorageKeyPrefixVerifyEmailAddressVerificationCodeEmailAddressRateLimit, clock, 5, time.Minute)
-	verifyUserPasswordResetTemporaryPasswordUserRateLimit := newTokenBucketRateLimit(rateLimitStorage, rateLimitStorageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit, clock, 5, time.Minute)
+	verifyUserPasswordRateLimit := newTokenBucketRateLimit(storage, storageKeyPrefixVerifyUserPasswordRateLimit, clock, 5, time.Minute)
+	sendEmailRateLimit := newTokenBucketRateLimit(storage, storageKeyPrefixSendEmailRateLimit, clock, 5, 30*time.Minute)
+	verifyEmailAddressVerificationCodeEmailAddressRateLimit := newTokenBucketRateLimit(storage, storageKeyPrefixVerifyEmailAddressVerificationCodeEmailAddressRateLimit, clock, 5, time.Minute)
+	verifyUserPasswordResetTemporaryPasswordUserRateLimit := newTokenBucketRateLimit(storage, storageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit, clock, 5, time.Minute)
 
 	action := &ServerStruct{
-		mainStorage:                    mainStorage,
-		cache:                          cache,
+		storage:                        storage,
 		userStore:                      userStore,
 		errorLogger:                    errorLogger,
 		userPasswordHashAlgorithms:     userPasswordHashAlgorithms,

--- a/server.go
+++ b/server.go
@@ -11,15 +11,16 @@ type ServerStruct struct {
 	mainStorage MainStorageInterface
 	cache       CacheInterface
 
-	errorLogger                        ActionErrorLoggerInterface
-	userPasswordHashAlgorithms         []PasswordHashAlgorithmInterface
-	temporaryPasswordHashAlgorithm     PasswordHashAlgorithmInterface
-	passwordHashingSemaphore           *semaphore.Weighted
-	clock                              ClockInterface
-	userServerInvocationEndpointClient ActionInvocationEndpointClientInterface
-	newEmailAddressChecker             EmailAddressCheckerInterface
-	emailSender                        EmailSenderInterface
-	sessionConfig                      SessionConfigStruct
+	userStore UserStoreInterface
+
+	errorLogger                    ActionErrorLoggerInterface
+	userPasswordHashAlgorithms     []PasswordHashAlgorithmInterface
+	temporaryPasswordHashAlgorithm PasswordHashAlgorithmInterface
+	passwordHashingSemaphore       *semaphore.Weighted
+	clock                          ClockInterface
+	newEmailAddressChecker         EmailAddressCheckerInterface
+	emailSender                    EmailSenderInterface
+	sessionConfig                  SessionConfigStruct
 
 	verifyUserPasswordRateLimit                             *tokenBucketRateLimit
 	sendEmailRateLimit                                      *tokenBucketRateLimit
@@ -41,6 +42,7 @@ func NewServer(
 	mainStorage MainStorageInterface,
 	cache CacheInterface,
 	rateLimitStorage RateLimitStorageInterface,
+	userStore UserStoreInterface,
 	errorLogger ActionErrorLoggerInterface,
 	userPasswordHashAlgorithms []PasswordHashAlgorithmInterface,
 	temporaryPasswordHashAlgorithm PasswordHashAlgorithmInterface,
@@ -48,7 +50,6 @@ func NewServer(
 	clock ClockInterface,
 	newEmailAddressChecker EmailAddressCheckerInterface,
 	emailSender EmailSenderInterface,
-	userServerActionInvocationEndpointClient ActionInvocationEndpointClientInterface,
 	sessionConfig SessionConfigStruct,
 ) *ServerStruct {
 	verifyUserPasswordRateLimit := newTokenBucketRateLimit(rateLimitStorage, rateLimitStorageKeyPrefixVerifyUserPasswordRateLimit, clock, 5, time.Minute)
@@ -57,17 +58,17 @@ func NewServer(
 	verifyUserPasswordResetTemporaryPasswordUserRateLimit := newTokenBucketRateLimit(rateLimitStorage, rateLimitStorageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit, clock, 5, time.Minute)
 
 	action := &ServerStruct{
-		mainStorage:                        mainStorage,
-		cache:                              cache,
-		errorLogger:                        errorLogger,
-		userPasswordHashAlgorithms:         userPasswordHashAlgorithms,
-		temporaryPasswordHashAlgorithm:     temporaryPasswordHashAlgorithm,
-		passwordHashingSemaphore:           semaphore.NewWeighted(int64(maxConcurrentPasswordHashingProcesses)),
-		clock:                              clock,
-		userServerInvocationEndpointClient: userServerActionInvocationEndpointClient,
-		newEmailAddressChecker:             newEmailAddressChecker,
-		emailSender:                        emailSender,
-		sessionConfig:                      sessionConfig,
+		mainStorage:                    mainStorage,
+		cache:                          cache,
+		userStore:                      userStore,
+		errorLogger:                    errorLogger,
+		userPasswordHashAlgorithms:     userPasswordHashAlgorithms,
+		temporaryPasswordHashAlgorithm: temporaryPasswordHashAlgorithm,
+		passwordHashingSemaphore:       semaphore.NewWeighted(int64(maxConcurrentPasswordHashingProcesses)),
+		clock:                          clock,
+		newEmailAddressChecker:         newEmailAddressChecker,
+		emailSender:                    emailSender,
+		sessionConfig:                  sessionConfig,
 
 		verifyUserPasswordRateLimit:                             verifyUserPasswordRateLimit,
 		sendEmailRateLimit:                                      sendEmailRateLimit,

--- a/session.go
+++ b/session.go
@@ -11,16 +11,9 @@ type sessionStruct struct {
 	userId              string
 	secretHash          []byte
 	tokenLastVerifiedAt time.Time
+	userLastCheckedAt   time.Time
 	userDisabledCounter int32
 	userSessionsCounter int32
-	createdAt           time.Time
-}
-
-type cachedSessionStruct struct {
-	id                  string
-	userId              string
-	secretHash          []byte
-	tokenLastVerifiedAt time.Time
 	createdAt           time.Time
 }
 
@@ -35,7 +28,7 @@ type SessionConfigStruct struct {
 	Expiration time.Duration
 
 	// Positive value. 0 if disabled
-	CacheExpiration time.Duration
+	UserCacheExpiration time.Duration
 }
 
 func (server *ServerStruct) verifySessionExpiration(session sessionStruct) bool {
@@ -50,19 +43,7 @@ func (server *ServerStruct) verifySessionExpiration(session sessionStruct) bool 
 	return true
 }
 
-func (server *ServerStruct) verifyCachedSessionExpiration(session cachedSessionStruct) bool {
-	now := server.clock.Now()
-
-	if server.sessionConfig.Expiration > 0 && now.Sub(session.createdAt) >= server.sessionConfig.Expiration {
-		return false
-	}
-	if now.Sub(session.tokenLastVerifiedAt) >= server.sessionConfig.InactivityTimeout {
-		return false
-	}
-	return true
-}
-
-func (server *ServerStruct) createSession(userId string, userDisabledCounter int32, userSessionsCounter int32) (cachedSessionStruct, string, error) {
+func (server *ServerStruct) createSession(userId string, userDisabledCounter int32, userSessionsCounter int32) (sessionStruct, string, error) {
 	id := generateRandomId()
 	secret := generateSecret()
 	secretHash := createCredentialSecretHash(secret)
@@ -79,169 +60,127 @@ func (server *ServerStruct) createSession(userId string, userDisabledCounter int
 	}
 	token := createCredentialToken(id, secret)
 
-	cachedSession, err := server.setSessionInStorage(session)
+	err := server.setSessionInStorage(session)
 	if err != nil {
-		return cachedSessionStruct{}, "", fmt.Errorf("failed to set session in storage: %s", err.Error())
+		return sessionStruct{}, "", fmt.Errorf("failed to set session in storage: %s", err.Error())
 	}
 
-	return cachedSession, token, nil
+	return session, token, nil
 }
 
-func (server *ServerStruct) validateSessionToken(sessionToken string) (cachedSessionStruct, error) {
+func (server *ServerStruct) validateSessionToken(sessionToken string) (sessionStruct, error) {
 	sessionId, sessionSecret, err := parseCredentialToken(sessionToken)
 	if err != nil {
-		return cachedSessionStruct{}, errInvalidSessionToken
+		return sessionStruct{}, errInvalidSessionToken
 	}
 
-	cachedSession, err := server.getValidSession(sessionId)
+	session, err := server.getValidSession(sessionId)
 	if err != nil && errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, errInvalidSessionToken
+		return sessionStruct{}, errInvalidSessionToken
 	}
 	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get valid session: %s", err.Error())
+		return sessionStruct{}, fmt.Errorf("failed to get valid session: %s", err.Error())
 	}
 
-	secretValid := verifyCredentialSecret(cachedSession.secretHash, sessionSecret)
+	secretValid := verifyCredentialSecret(session.secretHash, sessionSecret)
 	if !secretValid {
-		return cachedSessionStruct{}, errInvalidSessionToken
+		return sessionStruct{}, errInvalidSessionToken
 	}
 
 	now := server.clock.Now()
-	if now.Sub(cachedSession.tokenLastVerifiedAt) >= server.sessionConfig.ActivityCheckInterval {
-		err = server.updateSessionTokenLastVerifiedAt(cachedSession.id, now)
-		if err == nil {
-			cachedSession.tokenLastVerifiedAt = now
-
-			err = server.deleteSessionFromCache(sessionId)
-			if err != nil {
-				return cachedSessionStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-			}
-		} else if !errors.Is(err, errConflict) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to update session token last verified at: %s", err.Error())
-		}
-	}
-
-	return cachedSession, nil
-}
-
-func (server *ServerStruct) validateSessionTokenAndUser(sessionToken string) (cachedSessionStruct, UserStruct, error) {
-	sessionId, sessionSecret, err := parseCredentialToken(sessionToken)
-	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, errInvalidSessionToken
-	}
-
-	cachedSession, user, err := server.getValidSessionAndUser(sessionId)
-	if err != nil && errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, UserStruct{}, errInvalidSessionToken
-	}
-	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get valid session and user: %s", err.Error())
-	}
-
-	secretValid := verifyCredentialSecret(cachedSession.secretHash, sessionSecret)
-	if !secretValid {
-		return cachedSessionStruct{}, UserStruct{}, errInvalidSessionToken
-	}
-
-	now := server.clock.Now()
-	if now.Sub(cachedSession.tokenLastVerifiedAt) >= server.sessionConfig.ActivityCheckInterval {
-		err = server.updateSessionTokenLastVerifiedAt(cachedSession.id, now)
+	if now.Sub(session.tokenLastVerifiedAt) >= server.sessionConfig.ActivityCheckInterval {
+		err = server.updateSessionTokenLastVerifiedAt(session.id, now)
 		if err != nil && !errors.Is(err, errConflict) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to update session token last verified at: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to update session token last verified at: %s", err.Error())
 		}
 	}
 
-	return cachedSession, user, nil
+	return session, nil
 }
 
-func (server *ServerStruct) getValidSessionAndUser(sessionId string) (cachedSessionStruct, UserStruct, error) {
-	cachedSession, err := server.getSessionFromCache(sessionId)
-	if err == nil {
-		expirationValid := server.verifyCachedSessionExpiration(cachedSession)
-		if expirationValid {
-			user, err := server.userStore.GetUser(cachedSession.userId)
-			if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
-				err = server.deleteSessionFromCache(cachedSession.id)
-				if err != nil {
-					return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-				}
-				return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
-			}
-			if err != nil {
-				return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
-			}
-			if user.Disabled {
-				err = server.deleteSessionFromCache(cachedSession.id)
-				if err != nil {
-					return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-				}
-				return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
-			}
-
-			return cachedSession, user, nil
-		}
-
-		err = server.deleteSessionFromCache(cachedSession.id)
-		if err != nil {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-		}
-	}
-	if !errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get session from cache: %s", err.Error())
+func (server *ServerStruct) validateSessionTokenAndUser(sessionToken string) (sessionStruct, UserStruct, error) {
+	sessionId, sessionSecret, err := parseCredentialToken(sessionToken)
+	if err != nil {
+		return sessionStruct{}, UserStruct{}, errInvalidSessionToken
 	}
 
-	session, _, err := server.getSessionFromMainStorage(sessionId)
+	session, user, err := server.getValidSessionAndUser(sessionId)
 	if err != nil && errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errInvalidSessionToken
 	}
 	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get session from main storage: %s", err.Error())
+		return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to get valid session and user: %s", err.Error())
+	}
+
+	secretValid := verifyCredentialSecret(session.secretHash, sessionSecret)
+	if !secretValid {
+		return sessionStruct{}, UserStruct{}, errInvalidSessionToken
+	}
+
+	now := server.clock.Now()
+	if now.Sub(session.tokenLastVerifiedAt) >= server.sessionConfig.ActivityCheckInterval {
+		err = server.updateSessionTokenLastVerifiedAt(session.id, now)
+		if err != nil && !errors.Is(err, errConflict) {
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to update session token last verified at: %s", err.Error())
+		}
+	}
+
+	return session, user, nil
+}
+
+func (server *ServerStruct) getValidSessionAndUser(sessionId string) (sessionStruct, UserStruct, error) {
+	session, _, err := server.getSessionFromStorage(sessionId)
+	if err != nil && errors.Is(err, errSessionNotFound) {
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
+	}
+	if err != nil {
+		return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to get session from storage: %s", err.Error())
 	}
 
 	expirationValid := server.verifySessionExpiration(session)
 	if !expirationValid {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 
 	user, err := server.userStore.GetUser(session.userId)
 	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
+		return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
 	}
 	if user.Disabled {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 
 	if session.userDisabledCounter != user.DisabledCounter {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 	if session.userSessionsCounter != user.SessionsCounter {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 
-	cachedSession = cachedSessionStruct{
+	session = sessionStruct{
 		id:                  session.id,
 		userId:              session.userId,
 		secretHash:          session.secretHash,
@@ -249,95 +188,75 @@ func (server *ServerStruct) getValidSessionAndUser(sessionId string) (cachedSess
 		createdAt:           session.createdAt,
 	}
 
-	err = server.setSessionInCache(cachedSession)
-	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to set session in cache: %s", err.Error())
-	}
-
-	return cachedSession, user, nil
+	return session, user, nil
 }
 
-func (server *ServerStruct) getValidSession(sessionId string) (cachedSessionStruct, error) {
-	cachedSession, err := server.getSessionFromCache(sessionId)
-	if err == nil {
-		expirationValid := server.verifyCachedSessionExpiration(cachedSession)
-		if expirationValid {
-			return cachedSession, nil
-		}
-
-		err = server.deleteSessionFromCache(cachedSession.id)
-		if err != nil {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-		}
-	} else if !errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get cached session: %s", err.Error())
-	}
-
-	session, _, err := server.getSessionFromMainStorage(sessionId)
+func (server *ServerStruct) getValidSession(sessionId string) (sessionStruct, error) {
+	session, counter, err := server.getSessionFromStorage(sessionId)
 	if err != nil && errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get session from main storage: %s", err.Error())
+		return sessionStruct{}, fmt.Errorf("failed to get session from storage: %s", err.Error())
 	}
 
 	expirationValid := server.verifySessionExpiration(session)
 	if !expirationValid {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
+
+	if server.sessionConfig.UserCacheExpiration > 0 && server.clock.Now().Sub(session.userLastCheckedAt) < server.sessionConfig.UserCacheExpiration {
+		return session, nil
+	}
+
+	session.userLastCheckedAt = server.clock.Now()
 
 	user, err := server.userStore.GetUser(session.userId)
 	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
+		return sessionStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
 	}
 	if user.Disabled {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 
 	if session.userDisabledCounter != user.DisabledCounter {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 	if session.userSessionsCounter != user.SessionsCounter {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 
-	cachedSession = cachedSessionStruct{
-		id:                  session.id,
-		userId:              session.userId,
-		secretHash:          session.secretHash,
-		tokenLastVerifiedAt: session.tokenLastVerifiedAt,
-		createdAt:           session.createdAt,
+	if server.sessionConfig.UserCacheExpiration > 0 {
+		err = server.updateSessionInStorage(session, counter)
+		if err != nil && !errors.Is(err, errSessionNotFound) {
+			return sessionStruct{}, fmt.Errorf("failed to update session in storage: %s", err.Error())
+		}
 	}
 
-	err = server.setSessionInCache(cachedSession)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to set session in cache: %s", err.Error())
-	}
-
-	return cachedSession, nil
+	return session, nil
 }
 
 func (server *ServerStruct) deleteSession(sessionId string) error {
@@ -353,12 +272,12 @@ func (server *ServerStruct) deleteSession(sessionId string) error {
 }
 
 func (server *ServerStruct) updateSessionTokenLastVerifiedAt(sessionId string, tokenLastVerifiedAt time.Time) error {
-	session, storageEntryCounter, err := server.getSessionFromMainStorage(sessionId)
+	session, storageEntryCounter, err := server.getSessionFromStorage(sessionId)
 	if err != nil && errors.Is(err, errSessionNotFound) {
 		return errConflict
 	}
 	if err != nil {
-		return fmt.Errorf("failed to get session from main storage: %s", err.Error())
+		return fmt.Errorf("failed to get session from storage: %s", err.Error())
 	}
 
 	if session.tokenLastVerifiedAt.After(tokenLastVerifiedAt) {
@@ -378,60 +297,25 @@ func (server *ServerStruct) updateSessionTokenLastVerifiedAt(sessionId string, t
 	return nil
 }
 
-func (server *ServerStruct) setSessionInStorage(session sessionStruct) (cachedSessionStruct, error) {
-	err := server.setSessionInMainStorage(session)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to set session in main storage %s", err.Error())
-	}
-
-	cachedSession := cachedSessionStruct{
-		id:                  session.id,
-		userId:              session.userId,
-		secretHash:          session.secretHash,
-		tokenLastVerifiedAt: session.tokenLastVerifiedAt,
-		createdAt:           session.createdAt,
-	}
-
-	err = server.setSessionInCache(cachedSession)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to set session in cache: %s", err.Error())
-	}
-
-	return cachedSession, nil
-}
-
-func (server *ServerStruct) setSessionInMainStorage(session sessionStruct) error {
+func (server *ServerStruct) setSessionInStorage(session sessionStruct) error {
 	encoded := encodeSessionToBytes(session)
 	expiresAt := session.tokenLastVerifiedAt.Add(server.sessionConfig.InactivityTimeout)
 
-	err := server.mainStorage.Set(mainStorageKeyPrefixSession+session.id, encoded, expiresAt)
+	err := server.storage.Add(storageKeyPrefixSession+session.id, encoded, expiresAt)
 	if err != nil {
-		return fmt.Errorf("failed to set entry in main storage: %s", err.Error())
+		return fmt.Errorf("failed to set entry in storage: %s", err.Error())
 	}
 
 	return nil
 }
 
-func (server *ServerStruct) setSessionInCache(session cachedSessionStruct) error {
-	if server.sessionConfig.CacheExpiration > 0 {
-		encoded := encodeCachedSessionToBytes(session)
-
-		err := server.cache.Set(cacheKeyPrefixSession+session.id, encoded, server.sessionConfig.CacheExpiration)
-		if err != nil {
-			return fmt.Errorf("failed to set entry in cache: %s", err.Error())
-		}
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) getSessionFromMainStorage(sessionId string) (sessionStruct, int32, error) {
-	encoded, counter, err := server.mainStorage.Get(mainStorageKeyPrefixSession + sessionId)
-	if err != nil && errors.Is(err, ErrMainStorageEntryNotFound) {
+func (server *ServerStruct) getSessionFromStorage(sessionId string) (sessionStruct, int32, error) {
+	encoded, counter, err := server.storage.Get(storageKeyPrefixSession + sessionId)
+	if err != nil && errors.Is(err, ErrStorageEntryNotFound) {
 		return sessionStruct{}, 0, errSessionNotFound
 	}
 	if err != nil {
-		return sessionStruct{}, 0, fmt.Errorf("failed to get entry from main storage: %s", err.Error())
+		return sessionStruct{}, 0, fmt.Errorf("failed to get entry from storage: %s", err.Error())
 	}
 
 	decoded, err := decodeSessionFromBytes(encoded)
@@ -442,86 +326,28 @@ func (server *ServerStruct) getSessionFromMainStorage(sessionId string) (session
 	return decoded, counter, nil
 }
 
-func (server *ServerStruct) getSessionFromCache(sessionId string) (cachedSessionStruct, error) {
-	encoded, err := server.cache.Get(cacheKeyPrefixSession + sessionId)
-	if err != nil && errors.Is(err, ErrCacheEntryNotFound) {
-		return cachedSessionStruct{}, errSessionNotFound
-	}
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get entry from cache: %s", err.Error())
-	}
-
-	decoded, err := decodeCachedSessionFromBytes(encoded)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to decode session from bytes: %s", err.Error())
-	}
-
-	return decoded, nil
-}
-
 func (server *ServerStruct) deleteSessionFromStorage(sessionId string) error {
-	err := server.deleteSessionFromMainStorage(sessionId)
-	if err != nil && errors.Is(err, errSessionNotFound) {
-		return errSessionNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to delete session from main storage: %s", err.Error())
-	}
-
-	err = server.deleteSessionFromCache(sessionId)
-	if err != nil {
-		return fmt.Errorf("failed to delete session from cache: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) deleteSessionFromMainStorage(sessionId string) error {
-	err := server.mainStorage.Delete(mainStorageKeyPrefixSession + sessionId)
-	if err != nil && errors.Is(err, ErrMainStorageEntryNotFound) {
+	err := server.storage.Delete(storageKeyPrefixSession + sessionId)
+	if err != nil && errors.Is(err, ErrStorageEntryNotFound) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("failed to delete entry from main storage: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) deleteSessionFromCache(sessionId string) error {
-	err := server.cache.Delete(cacheKeyPrefixSession + sessionId)
-	if err != nil && errors.Is(err, ErrMainStorageEntryNotFound) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to delete entry from cache: %s", err.Error())
+		return fmt.Errorf("failed to delete entry from storage: %s", err.Error())
 	}
 
 	return nil
 }
 
 func (server *ServerStruct) updateSessionInStorage(session sessionStruct, storageEntryCounter int32) error {
-	err := server.updateSessionInMainStorage(session, storageEntryCounter)
-	if err != nil && errors.Is(err, errSessionNotFound) {
-		return errSessionNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to update session in main storage: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) updateSessionInMainStorage(session sessionStruct, storageEntryCounter int32) error {
 	encoded := encodeSessionToBytes(session)
 	expiresAt := session.tokenLastVerifiedAt.Add(server.sessionConfig.InactivityTimeout)
 
-	err := server.mainStorage.Update(mainStorageKeyPrefixSession+session.id, encoded, expiresAt, storageEntryCounter)
-	if err != nil && errors.Is(err, ErrMainStorageEntryNotFound) {
+	err := server.storage.Update(storageKeyPrefixSession+session.id, encoded, expiresAt, storageEntryCounter)
+	if err != nil && errors.Is(err, ErrStorageEntryNotFound) {
 		return errSessionNotFound
 	}
 	if err != nil {
-		return fmt.Errorf("failed to update entry in main storage: %s", err.Error())
+		return fmt.Errorf("failed to update entry in storage: %s", err.Error())
 	}
 
 	return nil
@@ -533,18 +359,9 @@ func encodeSessionToBytes(session sessionStruct) []byte {
 	binarySequence.addString(session.userId)
 	binarySequence.add(session.secretHash)
 	binarySequence.addInt64(session.tokenLastVerifiedAt.Unix())
+	binarySequence.addInt64(session.userLastCheckedAt.Unix())
 	binarySequence.addInt32(session.userDisabledCounter)
 	binarySequence.addInt32(session.userSessionsCounter)
-	binarySequence.addInt64(session.createdAt.Unix())
-	return binarySequence.encode()
-}
-
-func encodeCachedSessionToBytes(session cachedSessionStruct) []byte {
-	binarySequence := binarySequenceType{}
-	binarySequence.addString(session.id)
-	binarySequence.addString(session.userId)
-	binarySequence.add(session.secretHash)
-	binarySequence.addInt64(session.tokenLastVerifiedAt.Unix())
 	binarySequence.addInt64(session.createdAt.Unix())
 	return binarySequence.encode()
 }
@@ -579,15 +396,19 @@ func mapBinarySequenceToSession(binarySequence binarySequenceType) (sessionStruc
 	if err != nil {
 		return sessionStruct{}, fmt.Errorf("failed to get token last verified at unix: %s", err.Error())
 	}
-	userDisabledCounter, err := binarySequence.getInt32(4)
+	userLastCheckedAtUnix, err := binarySequence.getInt64(4)
+	if err != nil {
+		return sessionStruct{}, fmt.Errorf("failed to get user last check at unix: %s", err.Error())
+	}
+	userDisabledCounter, err := binarySequence.getInt32(5)
 	if err != nil {
 		return sessionStruct{}, fmt.Errorf("failed to get user disabled counter: %s", err.Error())
 	}
-	userSessionsCounter, err := binarySequence.getInt32(5)
+	userSessionsCounter, err := binarySequence.getInt32(6)
 	if err != nil {
 		return sessionStruct{}, fmt.Errorf("failed to get user sessions counter: %s", err.Error())
 	}
-	createdAtUnix, err := binarySequence.getInt64(6)
+	createdAtUnix, err := binarySequence.getInt64(7)
 	if err != nil {
 		return sessionStruct{}, fmt.Errorf("failed to get created at unix: %s", err.Error())
 	}
@@ -597,54 +418,9 @@ func mapBinarySequenceToSession(binarySequence binarySequenceType) (sessionStruc
 		userId:              userId,
 		secretHash:          secretHash,
 		tokenLastVerifiedAt: time.Unix(tokenLastVerifiedAtUnix, 0),
+		userLastCheckedAt:   time.Unix(userLastCheckedAtUnix, 0),
 		userDisabledCounter: userDisabledCounter,
 		userSessionsCounter: userSessionsCounter,
-		createdAt:           time.Unix(createdAtUnix, 0),
-	}
-
-	return session, nil
-}
-
-func decodeCachedSessionFromBytes(serialized []byte) (cachedSessionStruct, error) {
-	binarySequence, err := parseBinarySequenceBytes(serialized)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to parse binary sequence bytes: %s", err.Error())
-	}
-
-	session, err := mapBinarySequenceToCachedSession(binarySequence)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to map binary sequence to session: %s", err.Error())
-	}
-	return session, nil
-}
-
-func mapBinarySequenceToCachedSession(binarySequence binarySequenceType) (cachedSessionStruct, error) {
-	id, err := binarySequence.getString(0)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get id: %s", err.Error())
-	}
-	userId, err := binarySequence.getString(1)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get user id: %s", err.Error())
-	}
-	secretHash, err := binarySequence.get(2)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get secret hash: %s", err.Error())
-	}
-	tokenLastVerifiedAtUnix, err := binarySequence.getInt64(3)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get token last verified at unix: %s", err.Error())
-	}
-	createdAtUnix, err := binarySequence.getInt64(4)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get created at unix: %s", err.Error())
-	}
-
-	session := cachedSessionStruct{
-		id:                  id,
-		userId:              userId,
-		secretHash:          secretHash,
-		tokenLastVerifiedAt: time.Unix(tokenLastVerifiedAtUnix, 0),
 		createdAt:           time.Unix(createdAtUnix, 0),
 	}
 

--- a/session.go
+++ b/session.go
@@ -160,7 +160,7 @@ func (server *ServerStruct) getValidSessionAndUser(sessionId string) (cachedSess
 		expirationValid := server.verifyCachedSessionExpiration(cachedSession)
 		if expirationValid {
 			user, err := server.userStore.GetUser(cachedSession.userId)
-			if err != nil && errors.Is(err, ErrUserNotFound) {
+			if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 				err = server.deleteSessionFromCache(cachedSession.id)
 				if err != nil {
 					return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
@@ -208,7 +208,7 @@ func (server *ServerStruct) getValidSessionAndUser(sessionId string) (cachedSess
 	}
 
 	user, err := server.userStore.GetUser(session.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
 			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
@@ -291,7 +291,7 @@ func (server *ServerStruct) getValidSession(sessionId string) (cachedSessionStru
 	}
 
 	user, err := server.userStore.GetUser(session.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
 			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())

--- a/signin.go
+++ b/signin.go
@@ -87,7 +87,7 @@ func (server *ServerStruct) getValidSigninAndUser(signinId string) (signinStruct
 	}
 
 	user, err := server.userStore.GetUser(signin.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSigninFromMainStorage(signin.id)
 		if err != nil && !errors.Is(err, errSigninNotFound) {
 			return signinStruct{}, UserStruct{}, fmt.Errorf("failed to delete signin from main storage: %s", err.Error())

--- a/storage.go
+++ b/storage.go
@@ -6,118 +6,46 @@ import (
 )
 
 const (
-	mainStorageKeyPrefixSession                = "aaaa."
-	mainStorageKeyPrefixSignup                 = "aaab."
-	mainStorageKeyPrefixSignin                 = "aaac."
-	mainStorageKeyPrefixUserEmailAddressUpdate = "aaad."
-	mainStorageKeyPrefixUserPasswordUpdate     = "aaae."
-	mainStorageKeyPrefixUserPasswordReset      = "aaaf."
-	mainStorageKeyPrefixUserDeletion           = "aaag."
+	storageKeyPrefixSession                                                 = "aaam."
+	storageKeyPrefixSignup                                                  = "aaab."
+	storageKeyPrefixSignin                                                  = "aaac."
+	storageKeyPrefixUserEmailAddressUpdate                                  = "aaad."
+	storageKeyPrefixUserPasswordUpdate                                      = "aaae."
+	storageKeyPrefixUserPasswordReset                                       = "aaaf."
+	storageKeyPrefixUserDeletion                                            = "aaag."
+	storageKeyPrefixVerifyUserPasswordRateLimit                             = "aaah."
+	storageKeyPrefixSendEmailRateLimit                                      = "aaai."
+	storageKeyPrefixVerifyEmailAddressVerificationCodeEmailAddressRateLimit = "aaaj."
+	storageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit   = "aaak."
 )
 
-const (
-	cacheKeyPrefixSession = "aaaa."
-)
-
-const (
-	rateLimitStorageKeyPrefixVerifyUserPasswordRateLimit                             = "aaaa."
-	rateLimitStorageKeyPrefixSendEmailRateLimit                                      = "aaab."
-	rateLimitStorageKeyPrefixVerifyEmailAddressVerificationCodeEmailAddressRateLimit = "aaac."
-	rateLimitStorageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit   = "aaad."
-)
-
-// Keys have a maximum length of 128 bytes.
-type MainStorageInterface interface {
-	// Retrieves the value and counter associated with the given key, even those past expiration.
-	// Returns [ErrMainStorageEntryNotFound] if the key doesn't exist.
+// Keys have a maximum length of 255 bytes.
+type StorageInterface interface {
+	// Retrieves the value and counter associated with the given key
+	// Returns [ErrStorageEntryNotFound] if the key doesn't exist.
 	// An error is returned for any other failure.
 	Get(key string) ([]byte, int32, error)
 
-	// Stores the value under the given key, overwriting any existing value.
+	// Stores the value under the given key.
 	// The counter is set to 0.
 	// expiresAt is just a soft expiration hint.
-	// Entries past their expiration may be deleted but it is not required.
-	Set(key string, value []byte, expiresAt time.Time) error
+	// There is no requirement for the entry to be immediately deleted or considered invalid after expiration.
+	// Returns [ErrStorageEntryAlreadyExists] if the key already exists.
+	// An error is returned for any other failure.
+	Add(key string, value []byte, expiresAt time.Time) error
 
 	// Updates the value and TTL for the given key if the counter matches.
 	// expiresAt is just a soft expiration hint.
-	// Entries past their expiration may be deleted but it is not required.
-	// Returns [ErrMainStorageEntryNotFound] if the key doesn't exist or the counter doesn't match.
+	// There is no requirement for the entry to be immediately deleted or considered invalid after expiration.
+	// Returns [ErrStorageEntryNotFound] if the key doesn't exist or the counter doesn't match.
 	// An error is returned for any other failure.
 	Update(key string, value []byte, expiresAt time.Time, counter int32) error
 
 	// Removes the value associated with the given key.
-	// Returns [ErrMainStorageEntryNotFound] if the key doesn't exist.
+	// Returns [ErrStorageEntryNotFound] if the key doesn't exist.
 	// An error is returned for any other failure.
 	Delete(key string) error
 }
 
-var ErrMainStorageEntryNotFound = errors.New("entry not found in main storage")
-
-// Keys have a maximum length of 128 bytes.
-type RateLimitStorageInterface interface {
-	// Retrieves the value, ID, counter associated with the given key.
-	// It may return entires past its expiration hint.
-	// Returns [ErrMainStorageEntryNotFound] if the key doesn't exist.
-	// An error is returned for any other failure.
-	Get(key string) ([]byte, string, int32, error)
-
-	// Stores a value and ID under the given key.
-	// The counter is set to 0.
-	// expiresAt is just a soft expiration hint.
-	// Entries past their expiration may be deleted but it is not required.
-	// Returns [ErrRateLimitStorageEntryAlreadyExists] if the key already exists.
-	// An error is returned for any other failure.
-	Add(key string, value []byte, entryId string, expiresAt time.Time) error
-
-	// Updates the value and TTL for the given key if the ID and counter matches.
-	// expiresAt is just a soft expiration hint.
-	// Entries past their expiration may be deleted but it is not required.
-	// Returns [ErrRateLimitStorageEntryNotFound] if the key doesn't exist, the ID doesn't match, or the counter doesn't match.
-	// An error is returned for any other failure.
-	Update(key string, value []byte, expiresAt time.Time, entryId string, counter int32) error
-
-	// Removes the value associated with the given key.
-	// Returns [ErrRateLimitStorageEntryNotFound] if the key doesn't exist, the ID doesn't match, or the counter doesn't match.
-	// An error is returned for any other failure.
-	Delete(key string, entryId string, counter int32) error
-}
-
-var ErrRateLimitStorageEntryNotFound = errors.New("entry not found in rate limit storage")
-var ErrRateLimitStorageEntryAlreadyExists = errors.New("entry already exists in rate limit storage")
-
-// Keys have a maximum length of 128 bytes.
-type CacheInterface interface {
-	// Retrieves the value and counter associated with the given key.
-	// It should not return entries past its expiration.
-	// Returns [ErrCacheEntryNotFound] if the key doesn't exist.
-	// An error is returned for any other failure.
-	Get(key string) ([]byte, error)
-
-	// Stores the value under the given key, overwriting any existing value.
-	// The initial entry counter is set to 0.
-	Set(key string, value []byte, ttl time.Duration) error
-
-	// Removes the value associated with the given key.
-	Delete(key string) error
-}
-
-var ErrCacheEntryNotFound = errors.New("entry not found in cache")
-
-// Implements [CacheInterface].
-// Stores nothing.
-var EmptyCache = emptyCacheStruct{}
-
-type emptyCacheStruct struct{}
-
-func (emptyCacheStruct) Get(_ string) ([]byte, error) {
-	return nil, ErrCacheEntryNotFound
-}
-
-func (emptyCacheStruct) Set(_ string, _ []byte, _ time.Time) error {
-	return nil
-}
-
-func (emptyCacheStruct) Delete(_ string) error {
-	return nil
-}
+var ErrStorageEntryNotFound = errors.New("entry not found in storage")
+var ErrStorageEntryAlreadyExists = errors.New("entry already exists in storage")

--- a/storage.go
+++ b/storage.go
@@ -6,17 +6,17 @@ import (
 )
 
 const (
-	storageKeyPrefixSession                                                 = "aaam."
-	storageKeyPrefixSignup                                                  = "aaab."
-	storageKeyPrefixSignin                                                  = "aaac."
-	storageKeyPrefixUserEmailAddressUpdate                                  = "aaad."
-	storageKeyPrefixUserPasswordUpdate                                      = "aaae."
-	storageKeyPrefixUserPasswordReset                                       = "aaaf."
-	storageKeyPrefixUserDeletion                                            = "aaag."
-	storageKeyPrefixVerifyUserPasswordRateLimit                             = "aaah."
-	storageKeyPrefixSendEmailRateLimit                                      = "aaai."
-	storageKeyPrefixVerifyEmailAddressVerificationCodeEmailAddressRateLimit = "aaaj."
-	storageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit   = "aaak."
+	storageKeyPrefixSession                                                 = "aaah."
+	storageKeyPrefixSignup                                                  = "aaai."
+	storageKeyPrefixSignin                                                  = "aaaj."
+	storageKeyPrefixUserEmailAddressUpdate                                  = "aaak."
+	storageKeyPrefixUserPasswordUpdate                                      = "aaam."
+	storageKeyPrefixUserPasswordReset                                       = "aaan."
+	storageKeyPrefixUserDeletion                                            = "aaap."
+	storageKeyPrefixVerifyUserPasswordRateLimit                             = "aaaq."
+	storageKeyPrefixSendEmailRateLimit                                      = "aaar."
+	storageKeyPrefixVerifyEmailAddressVerificationCodeEmailAddressRateLimit = "aaas."
+	storageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit   = "aaat."
 )
 
 // Keys have a maximum length of 255 bytes.

--- a/user-deletion.go
+++ b/user-deletion.go
@@ -90,7 +90,7 @@ func (server *ServerStruct) getValidUserDeletionAndUser(userDeletionId string) (
 	}
 
 	user, err := server.userStore.GetUser(userDeletion.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteUserDeletionFromMainStorage(userDeletion.id)
 		if err != nil && errors.Is(err, errUserDeletionNotFound) {
 			return userDeletionStruct{}, UserStruct{}, fmt.Errorf("failed to delete user deletion from main storage: %s", err.Error())

--- a/user-email-address-update.go
+++ b/user-email-address-update.go
@@ -98,7 +98,7 @@ func (server *ServerStruct) getValidUserEmailAddressUpdateAndUser(userEmailAddre
 	}
 
 	user, err := server.userStore.GetUser(userEmailAddressUpdate.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteUserEmailAddressUpdateFromMainStorage(userEmailAddressUpdate.id)
 		if err != nil && !errors.Is(err, errUserEmailAddressUpdateNotFound) {
 			return userEmailAddressUpdateStruct{}, UserStruct{}, fmt.Errorf("failed to delete email address update from main storage: %s", err.Error())

--- a/user-password-reset.go
+++ b/user-password-reset.go
@@ -109,7 +109,7 @@ func (server *ServerStruct) getValidUserPasswordResetAndUser(userPasswordResetId
 	}
 
 	user, err := server.userStore.GetUser(userPasswordReset.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteUserPasswordResetFromMainStorage(userPasswordReset.id)
 		if err != nil && !errors.Is(err, errUserPasswordResetNotFound) {
 			return userPasswordResetStruct{}, UserStruct{}, fmt.Errorf("failed to delete user password reset from main storage: %s", err.Error())

--- a/user-password-update.go
+++ b/user-password-update.go
@@ -98,7 +98,7 @@ func (server *ServerStruct) getValidUserPasswordUpdateAndUser(userPasswordUpdate
 	}
 
 	user, err := server.userStore.GetUser(userPasswordUpdate.userId)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteUserPasswordUpdateFromMainStorage(userPasswordUpdate.id)
 		if err != nil && !errors.Is(err, errUserPasswordUpdateNotFound) {
 			return userPasswordUpdateStruct{}, UserStruct{}, fmt.Errorf("failed to delete user password update from main storage: %s", err.Error())

--- a/user-server.go
+++ b/user-server.go
@@ -50,7 +50,7 @@ func (userServerClient *UserServerClientStruct) CreateUser(emailAddress string, 
 				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return UserStruct{}, ErrUserEmailAddressAlreadyUsed
+				return UserStruct{}, ErrUserStoreUserEmailAddressAlreadyUsed
 			}
 			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -85,7 +85,7 @@ func (userServerClient *UserServerClientStruct) GetUser(userId string) (UserStru
 				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return UserStruct{}, ErrUserNotFound
+				return UserStruct{}, ErrUserStoreUserNotFound
 			}
 			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -120,7 +120,7 @@ func (userServerClient *UserServerClientStruct) GetUserByEmailAddress(emailAddre
 				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return UserStruct{}, ErrUserNotFound
+				return UserStruct{}, ErrUserStoreUserNotFound
 			}
 			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -157,10 +157,10 @@ func (userServerClient *UserServerClientStruct) UpdateUserEmailAddress(userId st
 				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return ErrUserNotFound
+				return ErrUserStoreUserNotFound
 			}
 			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return ErrUserEmailAddressAlreadyUsed
+				return ErrUserStoreUserEmailAddressAlreadyUsed
 			}
 			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -192,10 +192,10 @@ func (userServerClient *UserServerClientStruct) UpdateUserPasswordHash(userId st
 				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return ErrUserNotFound
+				return ErrUserStoreUserNotFound
 			}
 			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return ErrUserEmailAddressAlreadyUsed
+				return ErrUserStoreUserEmailAddressAlreadyUsed
 			}
 			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -221,10 +221,10 @@ func (userServerClient *UserServerClientStruct) IncrementUserSessionsCounter(use
 				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return ErrUserNotFound
+				return ErrUserStoreUserNotFound
 			}
 			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return ErrUserEmailAddressAlreadyUsed
+				return ErrUserStoreUserEmailAddressAlreadyUsed
 			}
 			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -249,7 +249,7 @@ func (userServerClient *UserServerClientStruct) DeleteUser(userId string) error 
 				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
 			}
 			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return ErrUserNotFound
+				return ErrUserStoreUserNotFound
 			}
 			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
 		}
@@ -261,7 +261,7 @@ func (userServerClient *UserServerClientStruct) DeleteUser(userId string) error 
 
 func (server *ServerStruct) checkEmailAddressAvailability(emailAddress string) (bool, error) {
 	_, err := server.userStore.GetUserByEmailAddress(emailAddress)
-	if err != nil && errors.Is(err, ErrUserNotFound) {
+	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		return true, nil
 	}
 	if err != nil {

--- a/user-server.go
+++ b/user-server.go
@@ -8,6 +8,16 @@ import (
 	"github.com/faroedev/go-json"
 )
 
+const (
+	userServerActionCreateUser                   = "create_user"
+	userServerActionGetUser                      = "get_user"
+	userServerActionGetUserByEmailAddress        = "get_user_by_email_address"
+	userServerActionUpdateUserEmailAddress       = "update_user_email_address"
+	userServerActionUpdateUserPasswordHash       = "update_user_password_hash"
+	userServerActionIncrementUserSessionsCounter = "increment_user_sessions_counter"
+	userServerActionDeleteUser                   = "delete_user"
+)
+
 // Use [NewUserServerClient].
 // Implements [UserStoreInterface].
 type UserServerClientStruct struct {

--- a/user-server.go
+++ b/user-server.go
@@ -1,0 +1,333 @@
+package faroe
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/faroedev/go-json"
+)
+
+// Use [NewUserServerClient].
+// Implements [UserStoreInterface].
+type UserServerClientStruct struct {
+	actionInvocationEndpointClient ActionInvocationEndpointClientInterface
+}
+
+func NewUserServerClient(actionInvocationEndpointClient ActionInvocationEndpointClientInterface) *UserServerClientStruct {
+	client := &UserServerClientStruct{actionInvocationEndpointClient: actionInvocationEndpointClient}
+	return client
+}
+
+func (userServerClient *UserServerClientStruct) CreateUser(emailAddress string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte) (UserStruct, error) {
+	encodedPasswordHash := base64.StdEncoding.EncodeToString(passwordHash)
+	encodedPasswordSalt := base64.StdEncoding.EncodeToString(passwordSalt)
+
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("email_address", emailAddress)
+	argumentsJSONBuilder.AddString("password_hash", encodedPasswordHash)
+	argumentsJSONBuilder.AddString("password_hash_algorithm_id", passwordHashAlgorithmId)
+	argumentsJSONBuilder.AddString("password_salt", encodedPasswordSalt)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, valuesJSONObject, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionCreateUser, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "email_address_already_used" {
+				return UserStruct{}, ErrUserEmailAddressAlreadyUsed
+			}
+			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return UserStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
+	}
+
+	user, err := mapJSONObjectToUser(userJSONObject)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
+	}
+
+	return user, nil
+}
+
+func (userServerClient *UserServerClientStruct) GetUser(userId string) (UserStruct, error) {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, valuesJSONObject, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionGetUser, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return UserStruct{}, ErrUserNotFound
+			}
+			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return UserStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
+	}
+
+	user, err := mapJSONObjectToUser(userJSONObject)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
+	}
+
+	return user, nil
+}
+
+func (userServerClient *UserServerClientStruct) GetUserByEmailAddress(emailAddress string) (UserStruct, error) {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("email_address", emailAddress)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, valuesJSONObject, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionGetUserByEmailAddress, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return UserStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return UserStruct{}, ErrUserNotFound
+			}
+			return UserStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return UserStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
+	}
+
+	user, err := mapJSONObjectToUser(userJSONObject)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
+	}
+
+	return user, nil
+}
+
+func (userServerClient *UserServerClientStruct) UpdateUserEmailAddress(userId string, emailAddress string, userEmailAddressCounter int32) error {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSONBuilder.AddString("email_address", emailAddress)
+	argumentsJSONBuilder.AddInt32("user_email_address_counter", userEmailAddressCounter)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, _, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionUpdateUserEmailAddress, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return ErrUserNotFound
+			}
+			if actionInvocationActionErr.errorCode == "email_address_already_used" {
+				return ErrUserEmailAddressAlreadyUsed
+			}
+			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (userServerClient *UserServerClientStruct) UpdateUserPasswordHash(userId string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte, userPasswordHashCounter int32) error {
+	encodedPasswordHash := base64.StdEncoding.EncodeToString(passwordHash)
+	encodedPasswordSalt := base64.StdEncoding.EncodeToString(passwordSalt)
+
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSONBuilder.AddString("password_hash", encodedPasswordHash)
+	argumentsJSONBuilder.AddString("password_hash_algorithm_id", passwordHashAlgorithmId)
+	argumentsJSONBuilder.AddString("password_salt", encodedPasswordSalt)
+	argumentsJSONBuilder.AddInt32("user_password_hash_counter", userPasswordHashCounter)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, _, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionUpdateUserPasswordHash, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return ErrUserNotFound
+			}
+			if actionInvocationActionErr.errorCode == "email_address_already_used" {
+				return ErrUserEmailAddressAlreadyUsed
+			}
+			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (userServerClient *UserServerClientStruct) IncrementUserSessionsCounter(userId string, userSessionsCounter int32) error {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSONBuilder.AddInt32("user_sessions_counter", userSessionsCounter)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, _, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionIncrementUserSessionsCounter, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return ErrUserNotFound
+			}
+			if actionInvocationActionErr.errorCode == "email_address_already_used" {
+				return ErrUserEmailAddressAlreadyUsed
+			}
+			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (userServerClient *UserServerClientStruct) DeleteUser(userId string) error {
+	argumentsJSONBuilder := json.NewObjectBuilder()
+	argumentsJSONBuilder.AddString("user_id", userId)
+	argumentsJSON := argumentsJSONBuilder.Done()
+
+	_, _, err := sendActionInvocationRequest(userServerClient.actionInvocationEndpointClient, userServerActionDeleteUser, argumentsJSON)
+	if err != nil {
+		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
+			if actionInvocationActionErr.errorCode == "internal_error" {
+				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "internal_conflict" {
+				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
+			}
+			if actionInvocationActionErr.errorCode == "user_not_found" {
+				return ErrUserNotFound
+			}
+			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
+		}
+		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (server *ServerStruct) checkEmailAddressAvailability(emailAddress string) (bool, error) {
+	_, err := server.userStore.GetUserByEmailAddress(emailAddress)
+	if err != nil && errors.Is(err, ErrUserNotFound) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to get user from user api: %s", err.Error())
+	}
+	return false, nil
+}
+
+func mapJSONObjectToUser(userJSON json.ObjectStruct) (UserStruct, error) {
+	userId, err := userJSON.GetString("id")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'id' field: %s", err.Error())
+	}
+	emailAddress, err := userJSON.GetString("email_address")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'email_address' field: %s", err.Error())
+	}
+	encodedPasswordHash, err := userJSON.GetString("password_hash")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'password_hash' field: %s", err.Error())
+	}
+	passwordHashAlgorithmId, err := userJSON.GetString("password_hash_algorithm_id")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'password_hash_algorithm_id' field: %s", err.Error())
+	}
+	encodedPasswordSalt, err := userJSON.GetString("password_salt")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'password_salt' field: %s", err.Error())
+	}
+	displayName, err := userJSON.GetString("display_name")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'display_name' field: %s", err.Error())
+	}
+	disabled, err := userJSON.GetBool("disabled")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'disabled' field: %s", err.Error())
+	}
+	emailAddressCounter, err := userJSON.GetInt32("email_address_counter")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'email_address_counter' field: %s", err.Error())
+	}
+	passwordHashCounter, err := userJSON.GetInt32("password_hash_counter")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'password_hash_counter' field: %s", err.Error())
+	}
+	disabledCounter, err := userJSON.GetInt32("disabled_counter")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'disabled_counter' field: %s", err.Error())
+	}
+	sessionsCounter, err := userJSON.GetInt32("sessions_counter")
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to read 'sessions_counter' field: %s", err.Error())
+	}
+
+	passwordHash, err := base64.StdEncoding.DecodeString(encodedPasswordHash)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to decode password hash: %s", err.Error())
+	}
+	passwordSalt, err := base64.StdEncoding.DecodeString(encodedPasswordSalt)
+	if err != nil {
+		return UserStruct{}, fmt.Errorf("failed to decode password salt: %s", err.Error())
+	}
+
+	user := UserStruct{
+		Id:                      userId,
+		EmailAddress:            emailAddress,
+		PasswordHash:            passwordHash,
+		PasswordSalt:            passwordSalt,
+		PasswordHashAlgorithmId: passwordHashAlgorithmId,
+		DisplayName:             displayName,
+		Disabled:                disabled,
+		EmailAddressCounter:     emailAddressCounter,
+		PasswordHashCounter:     passwordHashCounter,
+		DisabledCounter:         disabledCounter,
+		SessionsCounter:         sessionsCounter,
+	}
+
+	return user, nil
+}

--- a/user.go
+++ b/user.go
@@ -33,44 +33,44 @@ type UserStoreInterface interface {
 	// Creates a new user. The email address should be stored as-is, with the casing preserved.
 	// The email address counter, password hash counter, disabled counter, and sessions counter should be set to 0.
 	// Returns the created user if successful.
-	// Returns [ErrUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
+	// Returns [ErrUserStoreUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
 	// An error is returned for any other failure.
 	CreateUser(emailAddress string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte) (UserStruct, error)
 
 	// Gets a user.
-	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist.
 	// An error is returned for any other failure.
 	GetUser(userId string) (UserStruct, error)
 
 	// Gets a user by email address.
 	// The email address must match exactly, including letter casing.
-	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist.
 	// An error is returned for any other failure.
 	GetUserByEmailAddress(emailAddress string) (UserStruct, error)
 
 	// Updates a user's email address and increment a user's email address counter if the email address counter matches.
 	// The new email address should be stored as-is, with the casing preserved.
-	// Returns [ErrUserNotFound] if a user doesn't exist or the user's email address counter doesn't match.
-	// Returns [ErrUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist or the user's email address counter doesn't match.
+	// Returns [ErrUserStoreUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
 	// An error is returned for any other failure.
 	UpdateUserEmailAddress(userId string, emailAddress string, userEmailAddressCounter int32) error
 
 	// Updates a user's password hash, password hash algorithm ID, and password salt,
 	// as well as increment a user's email address counter, if the user password hash counter matches.
-	// Returns [ErrUserNotFound] if a user doesn't exist or the user's password hash counter doesn't match.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist or the user's password hash counter doesn't match.
 	// An error is returned for any other failure.
 	UpdateUserPasswordHash(userId string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte, userPasswordHashCounter int32) error
 
 	// Increments a user's sessions counter if the user's sessions counter matches.
-	// Returns [ErrUserNotFound] if a user doesn't exist or the user's sessions counter doesn't match.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist or the user's sessions counter doesn't match.
 	// An error is returned for any other failure.
 	IncrementUserSessionsCounter(userId string, userSessionsCounter int32) error
 
 	// Deletes a user.
-	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// Returns [ErrUserStoreUserNotFound] if a user doesn't exist.
 	// An error is returned for any other failure.
 	DeleteUser(userId string) error
 }
 
-var ErrUserNotFound = errors.New("user not found")
-var ErrUserEmailAddressAlreadyUsed = errors.New("user email address already used")
+var ErrUserStoreUserNotFound = errors.New("user not found")
+var ErrUserStoreUserEmailAddressAlreadyUsed = errors.New("user email address already used")

--- a/user.go
+++ b/user.go
@@ -1,12 +1,6 @@
 package faroe
 
-import (
-	"encoding/base64"
-	"errors"
-	"fmt"
-
-	"github.com/faroedev/go-json"
-)
+import "errors"
 
 const (
 	userServerActionCreateUser                   = "create_user"
@@ -18,329 +12,75 @@ const (
 	userServerActionDeleteUser                   = "delete_user"
 )
 
-type userStruct struct {
-	id                      string
-	emailAddress            string
-	passwordHash            []byte
-	passwordSalt            []byte
-	passwordHashAlgorithmId string
-	disabled                bool
-	displayName             string
-	emailAddressCounter     int32
-	passwordHashCounter     int32
-	disabledCounter         int32
-	sessionsCounter         int32
+type UserStruct struct {
+	// A unique ID.
+	Id string
+
+	// A unique email address.
+	EmailAddress string
+
+	PasswordHash []byte
+
+	PasswordSalt []byte
+
+	PasswordHashAlgorithmId string
+
+	Disabled bool
+
+	// An empty string if not defined.
+	DisplayName string
+
+	EmailAddressCounter int32
+
+	PasswordHashCounter int32
+
+	DisabledCounter int32
+
+	SessionsCounter int32
 }
 
-func (server *ServerStruct) createUser(emailAddress string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte) (userStruct, error) {
-	encodedPasswordHash := base64.StdEncoding.EncodeToString(passwordHash)
-	encodedPasswordSalt := base64.StdEncoding.EncodeToString(passwordSalt)
+type UserStoreInterface interface {
+	// Creates a new user. The email address should be stored as-is, with the casing preserved.
+	// The email address counter, password hash counter, disabled counter, and sessions counter should be set to 0.
+	// Returns the created user if successful.
+	// Returns [ErrUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
+	// An error is returned for any other failure.
+	CreateUser(emailAddress string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte) (UserStruct, error)
 
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("email_address", emailAddress)
-	argumentsJSONBuilder.AddString("password_hash", encodedPasswordHash)
-	argumentsJSONBuilder.AddString("password_hash_algorithm_id", passwordHashAlgorithmId)
-	argumentsJSONBuilder.AddString("password_salt", encodedPasswordSalt)
-	argumentsJSON := argumentsJSONBuilder.Done()
+	// Gets a user.
+	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// An error is returned for any other failure.
+	GetUser(userId string) (UserStruct, error)
 
-	_, valuesJSONObject, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionCreateUser, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return userStruct{}, errUserEmailAddressAlreadyUsed
-			}
-			return userStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return userStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
+	// Gets a user by email address.
+	// The email address must match exactly, including letter casing.
+	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// An error is returned for any other failure.
+	GetUserByEmailAddress(emailAddress string) (UserStruct, error)
 
-	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
-	}
+	// Updates a user's email address and increment a user's email address counter if the email address counter matches.
+	// The new email address should be stored as-is, with the casing preserved.
+	// Returns [ErrUserNotFound] if a user doesn't exist or the user's email address counter doesn't match.
+	// Returns [ErrUserEmailAddressAlreadyUsed] if the email address is already tied to another user.
+	// An error is returned for any other failure.
+	UpdateUserEmailAddress(userId string, emailAddress string, userEmailAddressCounter int32) error
 
-	user, err := mapJSONObjectToUser(userJSONObject)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
-	}
+	// Updates a user's password hash, password hash algorithm ID, and password salt,
+	// as well as increment a user's email address counter, if the user password hash counter matches.
+	// Returns [ErrUserNotFound] if a user doesn't exist or the user's password hash counter doesn't match.
+	// An error is returned for any other failure.
+	UpdateUserPasswordHash(userId string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte, userPasswordHashCounter int32) error
 
-	return user, nil
+	// Increments a user's sessions counter if the user's sessions counter matches.
+	// Returns [ErrUserNotFound] if a user doesn't exist or the user's sessions counter doesn't match.
+	// An error is returned for any other failure.
+	IncrementUserSessionsCounter(userId string, userSessionsCounter int32) error
+
+	// Deletes a user.
+	// Returns [ErrUserNotFound] if a user doesn't exist.
+	// An error is returned for any other failure.
+	DeleteUser(userId string) error
 }
 
-func (server *ServerStruct) getUser(userId string) (userStruct, error) {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, valuesJSONObject, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionGetUser, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return userStruct{}, errUserNotFound
-			}
-			return userStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return userStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
-	}
-
-	user, err := mapJSONObjectToUser(userJSONObject)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
-	}
-
-	return user, nil
-}
-
-func (server *ServerStruct) getUserByEmailAddress(emailAddress string) (userStruct, error) {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("email_address", emailAddress)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, valuesJSONObject, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionGetUserByEmailAddress, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return userStruct{}, fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return userStruct{}, errUserNotFound
-			}
-			return userStruct{}, fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return userStruct{}, fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	userJSONObject, err := valuesJSONObject.GetJSONObject("user")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'user' field from values json object: %s", err.Error())
-	}
-
-	user, err := mapJSONObjectToUser(userJSONObject)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to map json object to user: %s", err.Error())
-	}
-
-	return user, nil
-}
-
-func (server *ServerStruct) updateUserEmailAddress(userId string, emailAddress string, userEmailAddressCounter int32) error {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSONBuilder.AddString("email_address", emailAddress)
-	argumentsJSONBuilder.AddInt32("user_email_address_counter", userEmailAddressCounter)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, _, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionUpdateUserEmailAddress, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return errUserNotFound
-			}
-			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return errUserEmailAddressAlreadyUsed
-			}
-			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) updateUserPasswordHash(userId string, passwordHash []byte, passwordHashAlgorithmId string, passwordSalt []byte, userPasswordHashCounter int32) error {
-	encodedPasswordHash := base64.StdEncoding.EncodeToString(passwordHash)
-	encodedPasswordSalt := base64.StdEncoding.EncodeToString(passwordSalt)
-
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSONBuilder.AddString("password_hash", encodedPasswordHash)
-	argumentsJSONBuilder.AddString("password_hash_algorithm_id", passwordHashAlgorithmId)
-	argumentsJSONBuilder.AddString("password_salt", encodedPasswordSalt)
-	argumentsJSONBuilder.AddInt32("user_password_hash_counter", userPasswordHashCounter)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, _, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionUpdateUserPasswordHash, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return errUserNotFound
-			}
-			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return errUserEmailAddressAlreadyUsed
-			}
-			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) incrementUserSessionsCounter(userId string, userSessionsCounter int32) error {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSONBuilder.AddInt32("user_sessions_counter", userSessionsCounter)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, _, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionIncrementUserSessionsCounter, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return errUserNotFound
-			}
-			if actionInvocationActionErr.errorCode == "email_address_already_used" {
-				return errUserEmailAddressAlreadyUsed
-			}
-			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) deleteUser(userId string) error {
-	argumentsJSONBuilder := json.NewObjectBuilder()
-	argumentsJSONBuilder.AddString("user_id", userId)
-	argumentsJSON := argumentsJSONBuilder.Done()
-
-	_, _, err := sendActionInvocationRequest(server.userServerInvocationEndpointClient, userServerActionDeleteUser, argumentsJSON)
-	if err != nil {
-		if actionInvocationActionErr, ok := err.(*actionInvocationActionErrorStruct); ok {
-			if actionInvocationActionErr.errorCode == "internal_error" {
-				return fmt.Errorf("action invocation %s failed: internal error", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "internal_conflict" {
-				return fmt.Errorf("action invocation %s failed: internal conflict", actionInvocationActionErr.actionInvocationId)
-			}
-			if actionInvocationActionErr.errorCode == "user_not_found" {
-				return errUserNotFound
-			}
-			return fmt.Errorf("action invocation %s failed: unknown error code %s", actionInvocationActionErr.actionInvocationId, actionInvocationActionErr.errorCode)
-		}
-		return fmt.Errorf("failed to send action invocation request: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) checkEmailAddressAvailability(emailAddress string) (bool, error) {
-	_, err := server.getUserByEmailAddress(emailAddress)
-	if err != nil && errors.Is(err, errUserNotFound) {
-		return true, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("failed to get user from user api: %s", err.Error())
-	}
-	return false, nil
-}
-
-func mapJSONObjectToUser(userJSON json.ObjectStruct) (userStruct, error) {
-	userId, err := userJSON.GetString("id")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'id' field: %s", err.Error())
-	}
-	emailAddress, err := userJSON.GetString("email_address")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'email_address' field: %s", err.Error())
-	}
-	encodedPasswordHash, err := userJSON.GetString("password_hash")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'password_hash' field: %s", err.Error())
-	}
-	passwordHashAlgorithmId, err := userJSON.GetString("password_hash_algorithm_id")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'password_hash_algorithm_id' field: %s", err.Error())
-	}
-	encodedPasswordSalt, err := userJSON.GetString("password_salt")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'password_salt' field: %s", err.Error())
-	}
-	displayName, err := userJSON.GetString("display_name")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'display_name' field: %s", err.Error())
-	}
-	disabled, err := userJSON.GetBool("disabled")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'disabled' field: %s", err.Error())
-	}
-	emailAddressCounter, err := userJSON.GetInt32("email_address_counter")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'email_address_counter' field: %s", err.Error())
-	}
-	passwordHashCounter, err := userJSON.GetInt32("password_hash_counter")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'password_hash_counter' field: %s", err.Error())
-	}
-	disabledCounter, err := userJSON.GetInt32("disabled_counter")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'disabled_counter' field: %s", err.Error())
-	}
-	sessionsCounter, err := userJSON.GetInt32("sessions_counter")
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to read 'sessions_counter' field: %s", err.Error())
-	}
-
-	passwordHash, err := base64.StdEncoding.DecodeString(encodedPasswordHash)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to decode password hash: %s", err.Error())
-	}
-	passwordSalt, err := base64.StdEncoding.DecodeString(encodedPasswordSalt)
-	if err != nil {
-		return userStruct{}, fmt.Errorf("failed to decode password salt: %s", err.Error())
-	}
-
-	user := userStruct{
-		id:                      userId,
-		emailAddress:            emailAddress,
-		passwordHash:            passwordHash,
-		passwordSalt:            passwordSalt,
-		passwordHashAlgorithmId: passwordHashAlgorithmId,
-		displayName:             displayName,
-		disabled:                disabled,
-		emailAddressCounter:     emailAddressCounter,
-		passwordHashCounter:     passwordHashCounter,
-		disabledCounter:         disabledCounter,
-		sessionsCounter:         sessionsCounter,
-	}
-
-	return user, nil
-}
+var ErrUserNotFound = errors.New("user not found")
+var ErrUserEmailAddressAlreadyUsed = errors.New("user email address already used")

--- a/user.go
+++ b/user.go
@@ -2,16 +2,6 @@ package faroe
 
 import "errors"
 
-const (
-	userServerActionCreateUser                   = "create_user"
-	userServerActionGetUser                      = "get_user"
-	userServerActionGetUserByEmailAddress        = "get_user_by_email_address"
-	userServerActionUpdateUserEmailAddress       = "update_user_email_address"
-	userServerActionUpdateUserPasswordHash       = "update_user_password_hash"
-	userServerActionIncrementUserSessionsCounter = "increment_user_sessions_counter"
-	userServerActionDeleteUser                   = "delete_user"
-)
-
 type UserStruct struct {
 	// A unique ID.
 	Id string


### PR DESCRIPTION
Merges main storage, rate limit storage, and cache storage into one.

- Removes `mainStorage`, `rateLimitStorage`, and `cache` parameters from `NewSever()`.
- Adds `storage` parameter to `NewSever()`.
- Removes `MainStorageInterface`, `RateLimitStorageInterface`, and `CacheInterface`.
- Adds `StorageInterface`.
- Replaces `SessionConfigStruct.CacheExpiration` with `SessionConfigStruct.UserCacheExpiration`