### PR TITLE
Simplify storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ import "github.com/faroedev/faroe"
 
 func main() {
 	server := faroe.NewServer(
-		mainStorage,
-		cache,
-		rateLimitStorage,
+		storage,
 		userStore,
 		logger,
 		userPasswordHashAlgorithms,

--- a/actions.go
+++ b/actions.go
@@ -2239,7 +2239,7 @@ type actionSessionStruct struct {
 	expiresAtDefined bool
 }
 
-func (server *ServerStruct) createActionSession(session cachedSessionStruct) actionSessionStruct {
+func (server *ServerStruct) createActionSession(session sessionStruct) actionSessionStruct {
 	actionSession := actionSessionStruct{
 		id:               session.id,
 		userId:           session.userId,

--- a/session.go
+++ b/session.go
@@ -11,16 +11,9 @@ type sessionStruct struct {
 	userId              string
 	secretHash          []byte
 	tokenLastVerifiedAt time.Time
+	userLastCheckedAt   time.Time
 	userDisabledCounter int32
 	userSessionsCounter int32
-	createdAt           time.Time
-}
-
-type cachedSessionStruct struct {
-	id                  string
-	userId              string
-	secretHash          []byte
-	tokenLastVerifiedAt time.Time
 	createdAt           time.Time
 }
 
@@ -35,7 +28,7 @@ type SessionConfigStruct struct {
 	Expiration time.Duration
 
 	// Positive value. 0 if disabled
-	CacheExpiration time.Duration
+	UserCacheExpiration time.Duration
 }
 
 func (server *ServerStruct) verifySessionExpiration(session sessionStruct) bool {
@@ -50,19 +43,7 @@ func (server *ServerStruct) verifySessionExpiration(session sessionStruct) bool 
 	return true
 }
 
-func (server *ServerStruct) verifyCachedSessionExpiration(session cachedSessionStruct) bool {
-	now := server.clock.Now()
-
-	if server.sessionConfig.Expiration > 0 && now.Sub(session.createdAt) >= server.sessionConfig.Expiration {
-		return false
-	}
-	if now.Sub(session.tokenLastVerifiedAt) >= server.sessionConfig.InactivityTimeout {
-		return false
-	}
-	return true
-}
-
-func (server *ServerStruct) createSession(userId string, userDisabledCounter int32, userSessionsCounter int32) (cachedSessionStruct, string, error) {
+func (server *ServerStruct) createSession(userId string, userDisabledCounter int32, userSessionsCounter int32) (sessionStruct, string, error) {
 	id := generateRandomId()
 	secret := generateSecret()
 	secretHash := createCredentialSecretHash(secret)
@@ -79,169 +60,127 @@ func (server *ServerStruct) createSession(userId string, userDisabledCounter int
 	}
 	token := createCredentialToken(id, secret)
 
-	cachedSession, err := server.setSessionInStorage(session)
+	err := server.setSessionInStorage(session)
 	if err != nil {
-		return cachedSessionStruct{}, "", fmt.Errorf("failed to set session in storage: %s", err.Error())
+		return sessionStruct{}, "", fmt.Errorf("failed to set session in storage: %s", err.Error())
 	}
 
-	return cachedSession, token, nil
+	return session, token, nil
 }
 
-func (server *ServerStruct) validateSessionToken(sessionToken string) (cachedSessionStruct, error) {
+func (server *ServerStruct) validateSessionToken(sessionToken string) (sessionStruct, error) {
 	sessionId, sessionSecret, err := parseCredentialToken(sessionToken)
 	if err != nil {
-		return cachedSessionStruct{}, errInvalidSessionToken
+		return sessionStruct{}, errInvalidSessionToken
 	}
 
-	cachedSession, err := server.getValidSession(sessionId)
+	session, err := server.getValidSession(sessionId)
 	if err != nil && errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, errInvalidSessionToken
+		return sessionStruct{}, errInvalidSessionToken
 	}
 	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get valid session: %s", err.Error())
+		return sessionStruct{}, fmt.Errorf("failed to get valid session: %s", err.Error())
 	}
 
-	secretValid := verifyCredentialSecret(cachedSession.secretHash, sessionSecret)
+	secretValid := verifyCredentialSecret(session.secretHash, sessionSecret)
 	if !secretValid {
-		return cachedSessionStruct{}, errInvalidSessionToken
+		return sessionStruct{}, errInvalidSessionToken
 	}
 
 	now := server.clock.Now()
-	if now.Sub(cachedSession.tokenLastVerifiedAt) >= server.sessionConfig.ActivityCheckInterval {
-		err = server.updateSessionTokenLastVerifiedAt(cachedSession.id, now)
-		if err == nil {
-			cachedSession.tokenLastVerifiedAt = now
-
-			err = server.deleteSessionFromCache(sessionId)
-			if err != nil {
-				return cachedSessionStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-			}
-		} else if !errors.Is(err, errConflict) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to update session token last verified at: %s", err.Error())
-		}
-	}
-
-	return cachedSession, nil
-}
-
-func (server *ServerStruct) validateSessionTokenAndUser(sessionToken string) (cachedSessionStruct, UserStruct, error) {
-	sessionId, sessionSecret, err := parseCredentialToken(sessionToken)
-	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, errInvalidSessionToken
-	}
-
-	cachedSession, user, err := server.getValidSessionAndUser(sessionId)
-	if err != nil && errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, UserStruct{}, errInvalidSessionToken
-	}
-	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get valid session and user: %s", err.Error())
-	}
-
-	secretValid := verifyCredentialSecret(cachedSession.secretHash, sessionSecret)
-	if !secretValid {
-		return cachedSessionStruct{}, UserStruct{}, errInvalidSessionToken
-	}
-
-	now := server.clock.Now()
-	if now.Sub(cachedSession.tokenLastVerifiedAt) >= server.sessionConfig.ActivityCheckInterval {
-		err = server.updateSessionTokenLastVerifiedAt(cachedSession.id, now)
+	if now.Sub(session.tokenLastVerifiedAt) >= server.sessionConfig.ActivityCheckInterval {
+		err = server.updateSessionTokenLastVerifiedAt(session.id, now)
 		if err != nil && !errors.Is(err, errConflict) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to update session token last verified at: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to update session token last verified at: %s", err.Error())
 		}
 	}
 
-	return cachedSession, user, nil
+	return session, nil
 }
 
-func (server *ServerStruct) getValidSessionAndUser(sessionId string) (cachedSessionStruct, UserStruct, error) {
-	cachedSession, err := server.getSessionFromCache(sessionId)
-	if err == nil {
-		expirationValid := server.verifyCachedSessionExpiration(cachedSession)
-		if expirationValid {
-			user, err := server.userStore.GetUser(cachedSession.userId)
-			if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
-				err = server.deleteSessionFromCache(cachedSession.id)
-				if err != nil {
-					return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-				}
-				return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
-			}
-			if err != nil {
-				return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
-			}
-			if user.Disabled {
-				err = server.deleteSessionFromCache(cachedSession.id)
-				if err != nil {
-					return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-				}
-				return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
-			}
-
-			return cachedSession, user, nil
-		}
-
-		err = server.deleteSessionFromCache(cachedSession.id)
-		if err != nil {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-		}
-	}
-	if !errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get session from cache: %s", err.Error())
+func (server *ServerStruct) validateSessionTokenAndUser(sessionToken string) (sessionStruct, UserStruct, error) {
+	sessionId, sessionSecret, err := parseCredentialToken(sessionToken)
+	if err != nil {
+		return sessionStruct{}, UserStruct{}, errInvalidSessionToken
 	}
 
-	session, _, err := server.getSessionFromMainStorage(sessionId)
+	session, user, err := server.getValidSessionAndUser(sessionId)
 	if err != nil && errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errInvalidSessionToken
 	}
 	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get session from main storage: %s", err.Error())
+		return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to get valid session and user: %s", err.Error())
+	}
+
+	secretValid := verifyCredentialSecret(session.secretHash, sessionSecret)
+	if !secretValid {
+		return sessionStruct{}, UserStruct{}, errInvalidSessionToken
+	}
+
+	now := server.clock.Now()
+	if now.Sub(session.tokenLastVerifiedAt) >= server.sessionConfig.ActivityCheckInterval {
+		err = server.updateSessionTokenLastVerifiedAt(session.id, now)
+		if err != nil && !errors.Is(err, errConflict) {
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to update session token last verified at: %s", err.Error())
+		}
+	}
+
+	return session, user, nil
+}
+
+func (server *ServerStruct) getValidSessionAndUser(sessionId string) (sessionStruct, UserStruct, error) {
+	session, _, err := server.getSessionFromStorage(sessionId)
+	if err != nil && errors.Is(err, errSessionNotFound) {
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
+	}
+	if err != nil {
+		return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to get session from storage: %s", err.Error())
 	}
 
 	expirationValid := server.verifySessionExpiration(session)
 	if !expirationValid {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 
 	user, err := server.userStore.GetUser(session.userId)
 	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
+		return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
 	}
 	if user.Disabled {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 
 	if session.userDisabledCounter != user.DisabledCounter {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 	if session.userSessionsCounter != user.SessionsCounter {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, UserStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, UserStruct{}, errSessionNotFound
+		return sessionStruct{}, UserStruct{}, errSessionNotFound
 	}
 
-	cachedSession = cachedSessionStruct{
+	session = sessionStruct{
 		id:                  session.id,
 		userId:              session.userId,
 		secretHash:          session.secretHash,
@@ -249,95 +188,75 @@ func (server *ServerStruct) getValidSessionAndUser(sessionId string) (cachedSess
 		createdAt:           session.createdAt,
 	}
 
-	err = server.setSessionInCache(cachedSession)
-	if err != nil {
-		return cachedSessionStruct{}, UserStruct{}, fmt.Errorf("failed to set session in cache: %s", err.Error())
-	}
-
-	return cachedSession, user, nil
+	return session, user, nil
 }
 
-func (server *ServerStruct) getValidSession(sessionId string) (cachedSessionStruct, error) {
-	cachedSession, err := server.getSessionFromCache(sessionId)
-	if err == nil {
-		expirationValid := server.verifyCachedSessionExpiration(cachedSession)
-		if expirationValid {
-			return cachedSession, nil
-		}
-
-		err = server.deleteSessionFromCache(cachedSession.id)
-		if err != nil {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from cache: %s", err.Error())
-		}
-	} else if !errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get cached session: %s", err.Error())
-	}
-
-	session, _, err := server.getSessionFromMainStorage(sessionId)
+func (server *ServerStruct) getValidSession(sessionId string) (sessionStruct, error) {
+	session, counter, err := server.getSessionFromStorage(sessionId)
 	if err != nil && errors.Is(err, errSessionNotFound) {
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get session from main storage: %s", err.Error())
+		return sessionStruct{}, fmt.Errorf("failed to get session from storage: %s", err.Error())
 	}
 
 	expirationValid := server.verifySessionExpiration(session)
 	if !expirationValid {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
+
+	if server.sessionConfig.UserCacheExpiration > 0 && server.clock.Now().Sub(session.userLastCheckedAt) < server.sessionConfig.UserCacheExpiration {
+		return session, nil
+	}
+
+	session.userLastCheckedAt = server.clock.Now()
 
 	user, err := server.userStore.GetUser(session.userId)
 	if err != nil && errors.Is(err, ErrUserStoreUserNotFound) {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
+		return sessionStruct{}, fmt.Errorf("failed to get user from user api: %s", err.Error())
 	}
 	if user.Disabled {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 
 	if session.userDisabledCounter != user.DisabledCounter {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 	if session.userSessionsCounter != user.SessionsCounter {
 		err = server.deleteSessionFromStorage(session.id)
 		if err != nil && !errors.Is(err, errSessionNotFound) {
-			return cachedSessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
+			return sessionStruct{}, fmt.Errorf("failed to delete session from storage: %s", err.Error())
 		}
-		return cachedSessionStruct{}, errSessionNotFound
+		return sessionStruct{}, errSessionNotFound
 	}
 
-	cachedSession = cachedSessionStruct{
-		id:                  session.id,
-		userId:              session.userId,
-		secretHash:          session.secretHash,
-		tokenLastVerifiedAt: session.tokenLastVerifiedAt,
-		createdAt:           session.createdAt,
+	if server.sessionConfig.UserCacheExpiration > 0 {
+		err = server.updateSessionInStorage(session, counter)
+		if err != nil && !errors.Is(err, errSessionNotFound) {
+			return sessionStruct{}, fmt.Errorf("failed to update session in storage: %s", err.Error())
+		}
 	}
 
-	err = server.setSessionInCache(cachedSession)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to set session in cache: %s", err.Error())
-	}
-
-	return cachedSession, nil
+	return session, nil
 }
 
 func (server *ServerStruct) deleteSession(sessionId string) error {
@@ -353,12 +272,12 @@ func (server *ServerStruct) deleteSession(sessionId string) error {
 }
 
 func (server *ServerStruct) updateSessionTokenLastVerifiedAt(sessionId string, tokenLastVerifiedAt time.Time) error {
-	session, storageEntryCounter, err := server.getSessionFromMainStorage(sessionId)
+	session, storageEntryCounter, err := server.getSessionFromStorage(sessionId)
 	if err != nil && errors.Is(err, errSessionNotFound) {
 		return errConflict
 	}
 	if err != nil {
-		return fmt.Errorf("failed to get session from main storage: %s", err.Error())
+		return fmt.Errorf("failed to get session from storage: %s", err.Error())
 	}
 
 	if session.tokenLastVerifiedAt.After(tokenLastVerifiedAt) {
@@ -378,60 +297,25 @@ func (server *ServerStruct) updateSessionTokenLastVerifiedAt(sessionId string, t
 	return nil
 }
 
-func (server *ServerStruct) setSessionInStorage(session sessionStruct) (cachedSessionStruct, error) {
-	err := server.setSessionInMainStorage(session)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to set session in main storage %s", err.Error())
-	}
-
-	cachedSession := cachedSessionStruct{
-		id:                  session.id,
-		userId:              session.userId,
-		secretHash:          session.secretHash,
-		tokenLastVerifiedAt: session.tokenLastVerifiedAt,
-		createdAt:           session.createdAt,
-	}
-
-	err = server.setSessionInCache(cachedSession)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to set session in cache: %s", err.Error())
-	}
-
-	return cachedSession, nil
-}
-
-func (server *ServerStruct) setSessionInMainStorage(session sessionStruct) error {
+func (server *ServerStruct) setSessionInStorage(session sessionStruct) error {
 	encoded := encodeSessionToBytes(session)
 	expiresAt := session.tokenLastVerifiedAt.Add(server.sessionConfig.InactivityTimeout)
 
-	err := server.mainStorage.Set(mainStorageKeyPrefixSession+session.id, encoded, expiresAt)
+	err := server.storage.Add(storageKeyPrefixSession+session.id, encoded, expiresAt)
 	if err != nil {
-		return fmt.Errorf("failed to set entry in main storage: %s", err.Error())
+		return fmt.Errorf("failed to set entry in storage: %s", err.Error())
 	}
 
 	return nil
 }
 
-func (server *ServerStruct) setSessionInCache(session cachedSessionStruct) error {
-	if server.sessionConfig.CacheExpiration > 0 {
-		encoded := encodeCachedSessionToBytes(session)
-
-		err := server.cache.Set(cacheKeyPrefixSession+session.id, encoded, server.sessionConfig.CacheExpiration)
-		if err != nil {
-			return fmt.Errorf("failed to set entry in cache: %s", err.Error())
-		}
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) getSessionFromMainStorage(sessionId string) (sessionStruct, int32, error) {
-	encoded, counter, err := server.mainStorage.Get(mainStorageKeyPrefixSession + sessionId)
-	if err != nil && errors.Is(err, ErrMainStorageEntryNotFound) {
+func (server *ServerStruct) getSessionFromStorage(sessionId string) (sessionStruct, int32, error) {
+	encoded, counter, err := server.storage.Get(storageKeyPrefixSession + sessionId)
+	if err != nil && errors.Is(err, ErrStorageEntryNotFound) {
 		return sessionStruct{}, 0, errSessionNotFound
 	}
 	if err != nil {
-		return sessionStruct{}, 0, fmt.Errorf("failed to get entry from main storage: %s", err.Error())
+		return sessionStruct{}, 0, fmt.Errorf("failed to get entry from storage: %s", err.Error())
 	}
 
 	decoded, err := decodeSessionFromBytes(encoded)
@@ -442,86 +326,28 @@ func (server *ServerStruct) getSessionFromMainStorage(sessionId string) (session
 	return decoded, counter, nil
 }
 
-func (server *ServerStruct) getSessionFromCache(sessionId string) (cachedSessionStruct, error) {
-	encoded, err := server.cache.Get(cacheKeyPrefixSession + sessionId)
-	if err != nil && errors.Is(err, ErrCacheEntryNotFound) {
-		return cachedSessionStruct{}, errSessionNotFound
-	}
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get entry from cache: %s", err.Error())
-	}
-
-	decoded, err := decodeCachedSessionFromBytes(encoded)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to decode session from bytes: %s", err.Error())
-	}
-
-	return decoded, nil
-}
-
 func (server *ServerStruct) deleteSessionFromStorage(sessionId string) error {
-	err := server.deleteSessionFromMainStorage(sessionId)
-	if err != nil && errors.Is(err, errSessionNotFound) {
-		return errSessionNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to delete session from main storage: %s", err.Error())
-	}
-
-	err = server.deleteSessionFromCache(sessionId)
-	if err != nil {
-		return fmt.Errorf("failed to delete session from cache: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) deleteSessionFromMainStorage(sessionId string) error {
-	err := server.mainStorage.Delete(mainStorageKeyPrefixSession + sessionId)
-	if err != nil && errors.Is(err, ErrMainStorageEntryNotFound) {
+	err := server.storage.Delete(storageKeyPrefixSession + sessionId)
+	if err != nil && errors.Is(err, ErrStorageEntryNotFound) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("failed to delete entry from main storage: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) deleteSessionFromCache(sessionId string) error {
-	err := server.cache.Delete(cacheKeyPrefixSession + sessionId)
-	if err != nil && errors.Is(err, ErrMainStorageEntryNotFound) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to delete entry from cache: %s", err.Error())
+		return fmt.Errorf("failed to delete entry from storage: %s", err.Error())
 	}
 
 	return nil
 }
 
 func (server *ServerStruct) updateSessionInStorage(session sessionStruct, storageEntryCounter int32) error {
-	err := server.updateSessionInMainStorage(session, storageEntryCounter)
-	if err != nil && errors.Is(err, errSessionNotFound) {
-		return errSessionNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to update session in main storage: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (server *ServerStruct) updateSessionInMainStorage(session sessionStruct, storageEntryCounter int32) error {
 	encoded := encodeSessionToBytes(session)
 	expiresAt := session.tokenLastVerifiedAt.Add(server.sessionConfig.InactivityTimeout)
 
-	err := server.mainStorage.Update(mainStorageKeyPrefixSession+session.id, encoded, expiresAt, storageEntryCounter)
-	if err != nil && errors.Is(err, ErrMainStorageEntryNotFound) {
+	err := server.storage.Update(storageKeyPrefixSession+session.id, encoded, expiresAt, storageEntryCounter)
+	if err != nil && errors.Is(err, ErrStorageEntryNotFound) {
 		return errSessionNotFound
 	}
 	if err != nil {
-		return fmt.Errorf("failed to update entry in main storage: %s", err.Error())
+		return fmt.Errorf("failed to update entry in storage: %s", err.Error())
 	}
 
 	return nil
@@ -533,18 +359,9 @@ func encodeSessionToBytes(session sessionStruct) []byte {
 	binarySequence.addString(session.userId)
 	binarySequence.add(session.secretHash)
 	binarySequence.addInt64(session.tokenLastVerifiedAt.Unix())
+	binarySequence.addInt64(session.userLastCheckedAt.Unix())
 	binarySequence.addInt32(session.userDisabledCounter)
 	binarySequence.addInt32(session.userSessionsCounter)
-	binarySequence.addInt64(session.createdAt.Unix())
-	return binarySequence.encode()
-}
-
-func encodeCachedSessionToBytes(session cachedSessionStruct) []byte {
-	binarySequence := binarySequenceType{}
-	binarySequence.addString(session.id)
-	binarySequence.addString(session.userId)
-	binarySequence.add(session.secretHash)
-	binarySequence.addInt64(session.tokenLastVerifiedAt.Unix())
 	binarySequence.addInt64(session.createdAt.Unix())
 	return binarySequence.encode()
 }
@@ -579,15 +396,19 @@ func mapBinarySequenceToSession(binarySequence binarySequenceType) (sessionStruc
 	if err != nil {
 		return sessionStruct{}, fmt.Errorf("failed to get token last verified at unix: %s", err.Error())
 	}
-	userDisabledCounter, err := binarySequence.getInt32(4)
+	userLastCheckedAtUnix, err := binarySequence.getInt64(4)
+	if err != nil {
+		return sessionStruct{}, fmt.Errorf("failed to get user last check at unix: %s", err.Error())
+	}
+	userDisabledCounter, err := binarySequence.getInt32(5)
 	if err != nil {
 		return sessionStruct{}, fmt.Errorf("failed to get user disabled counter: %s", err.Error())
 	}
-	userSessionsCounter, err := binarySequence.getInt32(5)
+	userSessionsCounter, err := binarySequence.getInt32(6)
 	if err != nil {
 		return sessionStruct{}, fmt.Errorf("failed to get user sessions counter: %s", err.Error())
 	}
-	createdAtUnix, err := binarySequence.getInt64(6)
+	createdAtUnix, err := binarySequence.getInt64(7)
 	if err != nil {
 		return sessionStruct{}, fmt.Errorf("failed to get created at unix: %s", err.Error())
 	}
@@ -597,54 +418,9 @@ func mapBinarySequenceToSession(binarySequence binarySequenceType) (sessionStruc
 		userId:              userId,
 		secretHash:          secretHash,
 		tokenLastVerifiedAt: time.Unix(tokenLastVerifiedAtUnix, 0),
+		userLastCheckedAt:   time.Unix(userLastCheckedAtUnix, 0),
 		userDisabledCounter: userDisabledCounter,
 		userSessionsCounter: userSessionsCounter,
-		createdAt:           time.Unix(createdAtUnix, 0),
-	}
-
-	return session, nil
-}
-
-func decodeCachedSessionFromBytes(serialized []byte) (cachedSessionStruct, error) {
-	binarySequence, err := parseBinarySequenceBytes(serialized)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to parse binary sequence bytes: %s", err.Error())
-	}
-
-	session, err := mapBinarySequenceToCachedSession(binarySequence)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to map binary sequence to session: %s", err.Error())
-	}
-	return session, nil
-}
-
-func mapBinarySequenceToCachedSession(binarySequence binarySequenceType) (cachedSessionStruct, error) {
-	id, err := binarySequence.getString(0)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get id: %s", err.Error())
-	}
-	userId, err := binarySequence.getString(1)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get user id: %s", err.Error())
-	}
-	secretHash, err := binarySequence.get(2)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get secret hash: %s", err.Error())
-	}
-	tokenLastVerifiedAtUnix, err := binarySequence.getInt64(3)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get token last verified at unix: %s", err.Error())
-	}
-	createdAtUnix, err := binarySequence.getInt64(4)
-	if err != nil {
-		return cachedSessionStruct{}, fmt.Errorf("failed to get created at unix: %s", err.Error())
-	}
-
-	session := cachedSessionStruct{
-		id:                  id,
-		userId:              userId,
-		secretHash:          secretHash,
-		tokenLastVerifiedAt: time.Unix(tokenLastVerifiedAtUnix, 0),
 		createdAt:           time.Unix(createdAtUnix, 0),
 	}
 

--- a/storage.go
+++ b/storage.go
@@ -6,118 +6,46 @@ import (
 )
 
 const (
-	mainStorageKeyPrefixSession                = "aaaa."
-	mainStorageKeyPrefixSignup                 = "aaab."
-	mainStorageKeyPrefixSignin                 = "aaac."
-	mainStorageKeyPrefixUserEmailAddressUpdate = "aaad."
-	mainStorageKeyPrefixUserPasswordUpdate     = "aaae."
-	mainStorageKeyPrefixUserPasswordReset      = "aaaf."
-	mainStorageKeyPrefixUserDeletion           = "aaag."
+	storageKeyPrefixSession                                                   = "aaah."
+	storageKeyPrefixSignup                                                    = "aaai."
+	storageKeyPrefixSignin                                                    = "aaaj."
+	storageKeyPrefixUserEmailAddressUpdate                                    = "aaak."
+	storageKeyPrefixUserPasswordUpdate                                        = "aaam."
+	storageKeyPrefixUserPasswordReset                                         = "aaan."
+	storageKeyPrefixUserDeletion                                              = "aaap."
+	storageKeyPrefixVerifyUserPasswordTokenBucket                             = "aaaq."
+	storageKeyPrefixSendEmailTokenBucket                                      = "aaar."
+	storageKeyPrefixVerifyEmailAddressVerificationCodeEmailAddressTokenBucket = "aaas."
+	storageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserTokenBucket   = "aaat."
 )
 
-const (
-	cacheKeyPrefixSession = "aaaa."
-)
-
-const (
-	rateLimitStorageKeyPrefixVerifyUserPasswordRateLimit                             = "aaaa."
-	rateLimitStorageKeyPrefixSendEmailRateLimit                                      = "aaab."
-	rateLimitStorageKeyPrefixVerifyEmailAddressVerificationCodeEmailAddressRateLimit = "aaac."
-	rateLimitStorageKeyPrefixVerifyUserPasswordResetTemporaryPasswordUserRateLimit   = "aaad."
-)
-
-// Keys have a maximum length of 128 bytes.
-type MainStorageInterface interface {
-	// Retrieves the value and counter associated with the given key, even those past expiration.
-	// Returns [ErrMainStorageEntryNotFound] if the key doesn't exist.
+// Keys have a maximum length of 255 bytes.
+type StorageInterface interface {
+	// Retrieves the value and counter associated with the given key
+	// Returns [ErrStorageEntryNotFound] if the key doesn't exist.
 	// An error is returned for any other failure.
 	Get(key string) ([]byte, int32, error)
 
-	// Stores the value under the given key, overwriting any existing value.
+	// Stores the value under the given key.
 	// The counter is set to 0.
 	// expiresAt is just a soft expiration hint.
-	// Entries past their expiration may be deleted but it is not required.
-	Set(key string, value []byte, expiresAt time.Time) error
+	// There is no requirement for the entry to be immediately deleted or considered invalid after expiration.
+	// Returns [ErrStorageEntryAlreadyExists] if the key already exists.
+	// An error is returned for any other failure.
+	Add(key string, value []byte, expiresAt time.Time) error
 
 	// Updates the value and TTL for the given key if the counter matches.
 	// expiresAt is just a soft expiration hint.
-	// Entries past their expiration may be deleted but it is not required.
-	// Returns [ErrMainStorageEntryNotFound] if the key doesn't exist or the counter doesn't match.
+	// There is no requirement for the entry to be immediately deleted or considered invalid after expiration.
+	// Returns [ErrStorageEntryNotFound] if the key doesn't exist or the counter doesn't match.
 	// An error is returned for any other failure.
 	Update(key string, value []byte, expiresAt time.Time, counter int32) error
 
 	// Removes the value associated with the given key.
-	// Returns [ErrMainStorageEntryNotFound] if the key doesn't exist.
+	// Returns [ErrStorageEntryNotFound] if the key doesn't exist.
 	// An error is returned for any other failure.
 	Delete(key string) error
 }
 
-var ErrMainStorageEntryNotFound = errors.New("entry not found in main storage")
-
-// Keys have a maximum length of 128 bytes.
-type RateLimitStorageInterface interface {
-	// Retrieves the value, ID, counter associated with the given key.
-	// It may return entires past its expiration hint.
-	// Returns [ErrMainStorageEntryNotFound] if the key doesn't exist.
-	// An error is returned for any other failure.
-	Get(key string) ([]byte, string, int32, error)
-
-	// Stores a value and ID under the given key.
-	// The counter is set to 0.
-	// expiresAt is just a soft expiration hint.
-	// Entries past their expiration may be deleted but it is not required.
-	// Returns [ErrRateLimitStorageEntryAlreadyExists] if the key already exists.
-	// An error is returned for any other failure.
-	Add(key string, value []byte, entryId string, expiresAt time.Time) error
-
-	// Updates the value and TTL for the given key if the ID and counter matches.
-	// expiresAt is just a soft expiration hint.
-	// Entries past their expiration may be deleted but it is not required.
-	// Returns [ErrRateLimitStorageEntryNotFound] if the key doesn't exist, the ID doesn't match, or the counter doesn't match.
-	// An error is returned for any other failure.
-	Update(key string, value []byte, expiresAt time.Time, entryId string, counter int32) error
-
-	// Removes the value associated with the given key.
-	// Returns [ErrRateLimitStorageEntryNotFound] if the key doesn't exist, the ID doesn't match, or the counter doesn't match.
-	// An error is returned for any other failure.
-	Delete(key string, entryId string, counter int32) error
-}
-
-var ErrRateLimitStorageEntryNotFound = errors.New("entry not found in rate limit storage")
-var ErrRateLimitStorageEntryAlreadyExists = errors.New("entry already exists in rate limit storage")
-
-// Keys have a maximum length of 128 bytes.
-type CacheInterface interface {
-	// Retrieves the value and counter associated with the given key.
-	// It should not return entries past its expiration.
-	// Returns [ErrCacheEntryNotFound] if the key doesn't exist.
-	// An error is returned for any other failure.
-	Get(key string) ([]byte, error)
-
-	// Stores the value under the given key, overwriting any existing value.
-	// The initial entry counter is set to 0.
-	Set(key string, value []byte, ttl time.Duration) error
-
-	// Removes the value associated with the given key.
-	Delete(key string) error
-}
-
-var ErrCacheEntryNotFound = errors.New("entry not found in cache")
-
-// Implements [CacheInterface].
-// Stores nothing.
-var EmptyCache = emptyCacheStruct{}
-
-type emptyCacheStruct struct{}
-
-func (emptyCacheStruct) Get(_ string) ([]byte, error) {
-	return nil, ErrCacheEntryNotFound
-}
-
-func (emptyCacheStruct) Set(_ string, _ []byte, _ time.Time) error {
-	return nil
-}
-
-func (emptyCacheStruct) Delete(_ string) error {
-	return nil
-}
+var ErrStorageEntryNotFound = errors.New("entry not found in storage")
+var ErrStorageEntryAlreadyExists = errors.New("entry already exists in storage")


### PR DESCRIPTION
Merges main storage, rate limit storage, and cache storage into one.

- Removes `mainStorage`, `rateLimitStorage`, and `cache` parameters from `NewSever()`.
- Adds `storage` parameter to `NewSever()`.
- Removes `MainStorageInterface`, `RateLimitStorageInterface`, and `CacheInterface`.
- Adds `StorageInterface`.
- Replaces `SessionConfigStruct.CacheExpiration` with `SessionConfigStruct.UserCacheExpiration`